### PR TITLE
modifies baseurl in config to represent repo name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Matroska Specification
 email: 
 description:
-baseurl: "/mkv_jekyll_poc"
+baseurl: "/matroska-specification"
 url:
 twitter_username: 
 github_username: 


### PR DESCRIPTION
This modification allows links using the baseurl variable to persist when viewing the site on http://matroska-org.github.io/matroska-specification/