### PR TITLE
Adds a few more technical specification pages

### DIFF
--- a/diagram.md
+++ b/diagram.md
@@ -1,0 +1,243 @@
+---
+layout: default
+---
+
+<table border="5" align="center" id="simple"><tr><td> <table width="150" border="0"><tr><td bgcolor="#FFCCFF">Header</td> 
+        </tr><tr><td bgcolor="#FFCC99">Meta Seek Information</td> 
+        </tr><tr><td bgcolor="#FFFFCC">Segment Information</td> 
+        </tr><tr><td bgcolor="#00FFFF">Track</td> 
+        </tr><tr><td bgcolor="#FF6666">Chapters</td> 
+        </tr><tr><td height="73" bgcolor="#66FF99">Clusters</td> 
+        </tr><tr><td bgcolor="#FFCC00">Cueing Data</td> 
+        </tr><tr><td bgcolor="#66FF00">Attachment</td> 
+        </tr><tr><td height="31" bgcolor="#CC99FF">Tagging</td> 
+        </tr></table></td> 
+  </tr></table>
+
+<div align="center">Figure 1 </div> 
+
+The first thing you must realize is that none of these pictures are to scale. Next you have to know that these pictures are a vague representation of the layout of a Matroska file as a full representation would be just as complex as the [specs]({{site.baseurl}}/specification.html)  themselves.
+
+The first picture is a simple representation of a Matroska file.
+
+The [Header]({{site.baseurl}}/specification.html#EBMLBasics) contains information saying what EBML version this files was created with, andwhat type of EBML file this is. In our case it is a Matroska file.
+
+The [Metaseek]({{site.baseurl}}/specification.html#MetaSeekInformation) section contains an index of where all of the other groups are in the file arelocated, such as the Track information, Chapters, Tags, Cues, Attachments, andso on. This element isn't technicaly required, but you would have to searchthe entire file to find all of the other Level 1 elements if you did not haveit. This is because any of the items can occur in any order. For instance youcould have the chapters section in the middle of the Clusters. This is partof the flexibility of EBML and Matroska.
+
+The [SegmentInformation]({{site.baseurl}}/specification.html#SegmentInformation) section contains basic information relating to the whole file.This includes the title for the file, a unique ID so that the file can be identifiedaround the world, and if it is part of a series of files, the ID of the nextfile.
+
+The [Track]({{site.baseurl}}/specification.html#Track) section has basic information about each of the tracks. For instance, is it a video, audio or subtitle track? What resolution is the video? What sample rate is the audio? The Track section also says what codec to use to view the track, and has the codec's private data for the track.
+
+The [Chapters]({{site.baseurl}}/specification.html#Chapters) section lists all of the Chapters. Chapters are a way to set predefined points to jump to in video or audio.
+
+The [Clusters]({{site.baseurl}}/specification.html#Cluster)  section has all of the Clusters. These contain all of the video frames and audio for each track.
+
+The [Cueing Data]({{site.baseurl}}/specification.html#CueingData) section contains all of the cues. Cues are the index for each of the tracks. It is a lot like the MetaSeek, but this is used for seeking to a specific time when playing back the file. Without this it is possible to seek, but it is much more difficult because the player has to 'hunt and peck' through the file looking for the correct timecode.
+
+The [Attachment]({{site.baseurl}}/specification.html#Attachment)  section is for attaching any type of file you want to a Matroska file. You could attach anything, pictures, webpages, programs, even the codec needed to play back the file. What you attach is up to you. (Someone might even want to attach an Ogg, or maybe another Matroska file some day?!?) In the future we want to come up with a standard way to label things like an album cover of a CD.
+
+The [Tagging]({{site.baseurl}}/specification.html#Tagging)  section contains all of the [Tags]({{site.baseurl}}/tagging.html)  that relate to the the file and each of the tracks. These tags are just like the ID3 tags found in MP3's. It has information such as the singer or writer of a song, ctors that were in the video, or who made the video.
+
+# Order
+
+While EBML allows elements of the same level to be in no particular order, for better use in streaming contexts (and with no drawback for local playback) we have introduced a few [guidelines on the order of certain elements]({{site.baseurl}}/order.html).
+
+# Detailed Diagram
+
+<div align="center">
+<table border="5" align="center" id="detailed"><tr><td> <table width="600" border="0"><tr><td><table width="100%" border="0"><tr bgcolor="#FFCC66"><td width="65" height="54" bgcolor="#FFFF00">Level 0</td> 
+                <td><table width="100%" border="0"><tr><td width="150" bgcolor="#FFFF00">Grouping</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#FFFF00">Level 1</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#FFFF00">Level 2</td> 
+                                  <td bgcolor="#FFFF00">Level 3</td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr><tr><td> <table width="100%" border="0"><tr bgcolor="#FF99FF"><td width="65" bgcolor="#FF99FF">EBML</td> 
+                <td><table width="100%" border="0"><tr><td width="150" bgcolor="#FFCCFF">Header</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#FFCCFF">EBMLVersion</td> 
+                            <td><table width="100%" border="0"><tr><td width="90"> </td> 
+                                  <td> </td> 
+                                </tr></table></td> 
+                          </tr><tr><td width="90" bgcolor="#FFCCFF">DocType</td> 
+                            <td><table width="100%" border="0"><tr><td width="90"> </td> 
+                                  <td> </td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr><tr><td><table width="100%" border="0"><tr bgcolor="#999999"><td width="65" bgcolor="#999999">Segment</td> 
+                <td><table width="100%" border="0"><tr><td width="150" bgcolor="#FFCC99">Meta Seek Information</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#FFCC99">SeekHead</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#FFCC99">Seek</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#FFCC99">SeekID</td> 
+                                      </tr><tr><td bgcolor="#FFCC99">SeekPosition</td> 
+                                      </tr></table></td> 
+                                </tr><tr><td bgcolor="#FFCC99">Seek</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#FFCC99">SeekID</td> 
+                                      </tr><tr><td bgcolor="#FFCC99">SeekPosition</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#FFFFCC">Segment Information</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#FFFFCC">Info</td> 
+                            <td><table width="100%" border="0"><tr><td bgcolor="#FFFFCC">Title</td> 
+                                  <td> </td> 
+                                </tr><tr><td width="90" bgcolor="#FFFFCC">SegmentUID</td> 
+                                  <td> </td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#00FFFF">Track</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#00FFFF">Tracks</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#00FFFF">TrackEntry</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#00FFFF">Name</td> 
+                                      </tr><tr><td bgcolor="#00FFFF">TrackNumber</td> 
+                                      </tr><tr><td bgcolor="#00FFFF">TrackType</td> 
+                                      </tr></table></td> 
+                                </tr><tr><td bgcolor="#00FFFF">TrackEntry</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#00FFFF">Name</td> 
+                                      </tr><tr><td bgcolor="#00FFFF">TrackNumber</td> 
+                                      </tr><tr><td bgcolor="#00FFFF">TrackType</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#FF6666">Chapters</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#FF6666">Chapters</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#FF6666">Edition Entry</td> 
+                                  <td> </td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#66FF99">Clusters</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#66FF99">Cluster</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#66FF99">Timecode</td> 
+                                  <td> </td> 
+                                </tr><tr><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td bgcolor="#66FF99">Block</td> 
+                                </tr><tr><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#66FF99">Block</td> 
+                                      </tr><tr><td bgcolor="#66FF99">ReferenceBlock</td> 
+                                      </tr></table></td> 
+                                </tr><tr bgcolor="#66FF99"><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td>Block</td> 
+                                </tr></table></td> 
+                          </tr><tr><td bgcolor="#66FF99">Cluster</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#66FF99">Timecode</td> 
+                                  <td> </td> 
+                                </tr><tr bgcolor="#66FF99"><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td>Block</td> 
+                                </tr><tr bgcolor="#66FF99"><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td>Block</td> 
+                                </tr><tr bgcolor="#66FF99"><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td>Block</td> 
+                                </tr><tr><td bgcolor="#66FF99">BlockGroup</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#66FF99">Block</td> 
+                                      </tr><tr><td bgcolor="#66FF99">BlockDuration</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#FFCC00">Cueing Data</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" height="128" bgcolor="#FFCC00">Cues</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#FFCC33">CuePoint</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#FFCC00">CueTime</td> 
+                                      </tr><tr><td bgcolor="#FFCC00">CuePosition</td> 
+                                      </tr></table></td> 
+                                </tr><tr><td bgcolor="#FFCC33">CuePoint</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#FFCC00">CueTime</td> 
+                                      </tr><tr><td bgcolor="#FFCC00">CuePosition</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td bgcolor="#66FF00">Attachment</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#66FF00">Attachments</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#66FF00">AttachedFile</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#66FF00">FileName</td> 
+                                      </tr><tr><td bgcolor="#66FF00">FileData</td> 
+                                      </tr></table></td> 
+                                </tr><tr><td bgcolor="#66FF00">AttachedFile</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#66FF00">FileName</td> 
+                                      </tr><tr><td bgcolor="#66FF00">FileData</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr><tr><td height="31" bgcolor="#CC99FF">Tagging</td> 
+                      <td><table width="100%" border="0"><tr><td width="95" bgcolor="#CC99FF">Tags</td> 
+                            <td><table width="100%" border="0"><tr><td width="90" bgcolor="#CC99FF">Tag</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#CC99FF">MultiTitle</td> 
+                                      </tr><tr><td bgcolor="#CC99FF">Language</td> 
+                                      </tr></table></td> 
+                                </tr><tr><td bgcolor="#CC99FF">Tag</td> 
+                                  <td><table width="100%" border="0"><tr><td bgcolor="#CC99FF">MultiTitle</td> 
+                                      </tr><tr><td bgcolor="#CC99FF">Language</td> 
+                                      </tr></table></td> 
+                                </tr></table></td> 
+                          </tr></table></td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr></table></td> 
+  </tr></table>
+<div align="center">Figure 2 </div> 
+
+Here is a more complex representation of a Matroska file. This one lists some of the elements for examples. Each of these elements are described in the [specs]({{site.baseurl}}/specification.html).
+
+The [Header]({{site.baseurl}}/specification.html#EBMLBasics) must occur at the beginning of the file. This is how the library knows whether or not it can read the file. The design of EBML is pretty straight forward and is its own project on [SourceForge](http://ebml.sourceforge.net/). EBML is not just for Matroska, there are many different potential applications for it. As such, there is the possibility of there being new versions, such as a 2.0 design. The [EBMLVersion]({{site.baseurl}}/specification.html#EBMLVersion) element would let the parser know first if it can read this file at all. If the EBMLVersion is set to 2.0, and the library is only able to read up to 1.2, then it knows it shouldn't even attempt to read this file. 
+
+The [DocType]({{site.baseurl}}/specification.html#DocType) tells us that this is a Matroska file. If the DocType says that this is a "Bob's Container Format", then any parser designed for Matrsoka will know right away that even if it can parse the EBML,its not going to know what to do with the data inside of this file.
+
+The [MetaSeek]({{site.baseurl}}/specification.html#MetaSeekInformation) section is to let the parser know where the other major parts of the file are. The design is pretty simple. You should normally have just one [SeekHead]({{site.baseurl}}/specification.html#SeekHead) in a file. You then have a couple of [Seek]({{site.baseurl}}/specification.html#Seek) entries. One for each seek point. The [SeekID]({{site.baseurl}}/specification.html#SeekID) contains the "Class-ID" of a level 1 element. For example, the [Tracks]({{site.baseurl}}/specification.html#Tracks) element has a Class-ID of "[16][54][AE][6B]". You would put that inthe SeekID, and then the byte position of that particular element in [SeekPosition]({{site.baseurl}}/specification.html#SeekPosition). The Meta Seek section is usually just used when the file is openned so that it can get information about the file. Any seeking that happens when playing back the file uses the Cues.
+
+The [Segment Information]({{site.baseurl}}/specification.html#SegmentInformation) portion gives us information that is vital to identifying the file. This includes the [Title]({{site.baseurl}}/specification.html#Title)  of the file and a [SegmentUID]({{site.baseurl}}/specification.html#SegmentUID)  that is used to identify the file. The ID is a randomly generated number. It also has the ID of any file that should be associated with it.
+
+The [Track]({{site.baseurl}}/specification.html#Track) portion tells us the technical side of what is in each track. The name of the track goes in [Name]({{site.baseurl}}/specification.html#Name). The tracks number goes into the [TrackNumber]({{site.baseurl}}/specification.html#TrackNumber) element. And the [TrackType]({{site.baseurl}}/specification.html#TrackType)  tells us what the track contains, such as audio, video, subtitles, etc. There are also settings to tell us what [language]({{site.baseurl}}/specification.html#language) it is in, and what [codec]({{site.baseurl}}/specification.html#CodecID)  to use for playback of the track. Each Track has a unique ID called [TrackUID]({{site.baseurl}}/specification.html#TrackUID), much like the ID for the whole file. This can be used when you are editing files and have several different versions, it makes it easy to see what files have that specific track. The TrackUID is also used in the [Tagging]({{site.baseurl}}/specification.html#Tagging) system.
+
+I am, unfortunately, unable to give a more detailed description of [Chapters]({{site.baseurl}}/specification.html#Chapters) at this time. I will describe these better when possible. Look at the specs for more information.
+
+In a given Matroska file, there are usually many [Clusters]({{site.baseurl}}/specification.html#Cluster). The Clusters help to break up the [Blocks]({{site.baseurl}}/specification.html#Block)  some and help with seeking and with error protection. There is no set limit to how much data a Cluster can contain, or how much time they can span, but so far developers seem to like to place the limit at 5 seconds or 5 megabytes. At the beginning of every Cluster is a timecode. This timecode is usually the timecode that the first Block in the Cluster should be played back, but it doesn't have to be. Then there are one or more (usually many more) [BlockGroups]({{site.baseurl}}/specification.html#BlockGroup)  in each Cluster. A BlockGroup can contain a Block of data, and any information relating directly to that Block. For a more detailed description of the Block stucture, see picture 3.
+
+The [ReferenceBlock]({{site.baseurl}}/specification.html#ReferenceBlock)  shown above, in the BlockGroup, is what we use instead of the basic "P-frame"/"B-frame" description. Instead of simply saying that this Block depends on the Block directly before, or directly afterwards, we put the timecode of the needed Block. And because you can have as many ReferenceBlock elements as you want for a Block, it allows for some extremely complex referencing.
+
+The [Cues]({{site.baseurl}}/specification.html#Cues) are what is used to seek when playing back a file. They form what is commonly known as an 'index'. In a single [CuePoint]({{site.baseurl}}/specification.html#CuePoint), you have the timecode store in [CueTime]({{site.baseurl}}/specification.html#CueTime), and then a listing for the exact position in the file for each of the tracks for that timecode. The Cues are pretty flexible for what exactly you want to index. For instance, you can index every single timecode of every Block, in every track if you liked, but you don't really need to. If you have a video file, you really just need to index the keyframes of the video track. 
+
+The Attachments is a pretty simple design. You have an [AttachedFile]({{site.baseurl}}/specification.html#AttachedFile) element. Inside of this you have the files name stored in [FileName]({{site.baseurl}}/specification.html#FileName), and the file itself is stored in [FileData]({{site.baseurl}}/specification.html#FileData). You can also list a more [readable name]({{site.baseurl}}/specification.html#FileDescription) and the [MIME-type]({{site.baseurl}}/specification.html#FileMimeType).
+
+And the [Tags]({{site.baseurl}}/tagging.html). These are possibly the most complex part of Matroska. Under the Tags element, you can have many Tag elements. Each Tag element contains all of the information pertaining to specific Track(s) and/or Chapter(s). Each Track or Chapter that those tags applies to has its UID listed in the tags. The Tags contain all extra information about the file, script writer, singer, actors, directors, titles, edition, price, dates, genre, comments, etc. And it allows you to enter many of these (title, edition, comments, ect) in different languages.
+
+<div align="center">
+<table border="5" align="center"><tr><td> <table width="335"><tr><td><table bgcolor="#FFCC00" width="100%" border="0"><tr><td width="110" bgcolor="#FFFF00">Portion of Block</td> 
+                <td><table width="100%" border="0"><tr><td width="100" bgcolor="#FFFF00">Data Type</td> 
+                      <td><table width="100%" border="0"><tr><td bgcolor="#FFFF00">Bit Flag</td> 
+                          </tr></table></td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr><tr><td><table bgcolor="#CCCCFF" width="100%" border="0"><tr><td width="110" bgcolor="#CCFFFF">Header </td> 
+                <td><table width="100%" border="0"><tr><td width="100" bgcolor="#CCFFFF">TrackNumber</td> 
+                      <td> </td> 
+                    </tr><tr><td bgcolor="#CCFFFF">Timecode</td> 
+                      <td> </td> 
+                    </tr><tr><td bgcolor="#CCFFFF">Flags</td> 
+                      <td><table width="100%" border="0"><tr><td bgcolor="#CCFFFF">Gap</td> 
+                          </tr><tr><td bgcolor="#CCFFFF">Lacing</td> 
+                          </tr><tr><td bgcolor="#CCFFFF">Reserved</td> 
+                          </tr></table></td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr><tr><td><table bgcolor="#FF9999" width="100%" border="0"><tr><td width="110" bgcolor="#FFCC99">Optional</td> 
+                <td><table width="100%" border="0"><tr><td width="100" bgcolor="#FFCC99">LaceNumber</td> 
+                      <td bgcolor="#FF9999"> </td> 
+                    </tr><tr><td bgcolor="#FFCC99">FrameSize</td> 
+                      <td> </td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr><tr><td><table bgcolor="#9999FF" width="100%" border="0"><tr><td width="110" bgcolor="#99CCFF">Data</td> 
+                <td><table width="100%" border="0"><tr><td width="100" bgcolor="#99CCFF">Frame</td> 
+                      <td> </td> 
+                    </tr></table></td> 
+              </tr></table></td> 
+        </tr></table></td> 
+  </tr></table></div>
+<div align="center">Figure 3 </div> 
+
+Here is a representation of the Block structure. There is an in depth discussion of it in the specs. I will add some descriptions here when I have time.
+
+One thing that I do want to mention however, to avoid confusion, is the Timecode. The quick eye will notice that there is one Timecode shown per Cluster, and then another within the Block structure itself. The way that this works is the Timecode in the Cluster is relative to the whole file. It is usually the Timecode that the first Block in the Cluster needs to be played at. The Timecode in the Block itself is relative to the Timecode in the Cluster. For example, lets say that the Timecode in the Cluster is set to 10 seconds, and you have a Block in that Cluster that is supposed to be played 12 seconds into the clip. This means that the Timecode in the Block would be set to 2 seconds.
+ 

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,430 @@
+---
+layout: default
+---
+
+#### If you intend to implement a Matroska player, make sure you can handle all the files in [our test suite](http://www.matroska.org/downloads/test_w1.html), or at least the features presented there, not necessarily the same codecs.
+
+### Beginning of File
+An EBML file always starts with 0x1A. The 0x1A makes the DOS command "type"
+  ends display. That way you can include ASCII text before the EBML data and it
+  can be displayed. The EBML parser is safe from false-alarm with these ASCII
+  only codes. 
+Next the EBML header is stored. This allows the the parser to know what type
+  of EBML file it is parsing.
+
+
+### Block Timecodes
+
+The Block's timecode is signed interger that represents the Raw Timecode
+  relative to the <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a>,
+  multiplied by the TimecodeScale. (see the <a href="notes.html#TimecodeScale">TimecodeScale
+  notes</a>)
+The Block's timecode is represented by a 16bit signed interger (sint16). This
+  means that the Blocks timecode has a range of -32768 to +32767 units.. When
+  using the default value of TimecodeScale, each integer represents 1ms. So, the
+  maximum time span of Blocks in a Cluster using the default TimecodeScale of
+  1ms is 65536ms. 
+The quick eye will notice that if a <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a> is set to zero, it is
+  possible to have Blocks with a negative Raw Timecode. Blocks with a negative
+  Raw Timecode are not valid.
+
+
+### Default decoded field duration
+
+This element can signal the displaying application how often fields
+of a video sequence will be available for displaying. It can be used
+for both interlaced and progressive content.
+
+If the video sequence is signaled as interlaced, the period between
+ two successive fields at the output of the decoding process equals
+ DefaultDecodedFieldDuration.
+
+For video sequences signaled as progressive it is twice the value
+ of DefaultDecodedFieldDuration.
+
+These values are valid at the end of the decoding process before
+ post-processing like deinterlacing or inverse telecine is applied.
+
+Examples:
+
+<ol><li>Blu-ray movie: 1000000000ns/(48/1.001) = 20854167ns</li>
+ <li>PAL broadcast/DVD: 1000000000ns/(50/1.000) = 20000000ns</li>
+ <li>N/ATSC broadcast: 1000000000ns/(60/1.001) = 16683333ns</li>
+ <li>hard-telecined DVD: 1000000000ns/(60/1.001) = 16683333ns (60
+  encoded interlaced fields per second)</li>
+ <li>soft-telecined DVD: 1000000000ns/(60/1.001) = 16683333ns   (48
+  encoded interlaced fields per second, with "repeat_first_field = 1")</li>
+</ol>
+
+### Default Values
+
+The default value of an element is assumed when not present in the data stream.
+  It is assumed only in the scope of its upper-element (for example Language in
+  the scope of the Track element). If the upper element is not present or assumed,
+  then the element cannot be assumed.
+
+
+### DRM
+Digital Rights Management. See <a href="#Encryption">Encryption</a>.
+
+
+### EBML Class
+A larger EBML class typically means the element has a lower probability/importance.
+  A larger Class-ID can be used as a synch word in case the file is damaged. Elements
+  that are used frequently, but do not need to act as a synch word, should have
+  a small Class-ID.
+For example, the Cluster has a 4 octect ID and can be used as a synch word
+  if the file is damaged. However, the every common element in the BlockGroup
+  has a single octet ID to conserve space because of how frequently it is used.
+
+
+### Encryption
+Encryption in Matroska is designed in a very generic style that allows people
+  to implement whatever form of encryption is best for them. It is easily possible
+  to use the encryption framework in Matroska as a type of DRM.
+Because the encryption occurs within the Block, it is possible to manipulate
+  encrypted streams without decrypting them. The streams could potentially be
+  copied, deleted, cut, appended, or any number of other possible editing techniques
+  without ever decrypting them. This means that the data is more useful, without
+  having to expose it, or go through the intensive process of decrypting.
+Encryption can also be layered within Matroska. This means that two completely
+  different types of encryption can be used, requiring two seperate keys to be
+  able to decrypt a stream. 
+Encryption information is stored in the ContentEncodings section under the
+  ContentEncryption element.
+
+
+### Image cropping
+Thanks to the PixelCropXXX elements, it's possible to crop the image before being resized. That means the image size follows this path :
+PixelXXX (size of the coded image) -&gt; PixelCropXXX (size of the image to keep) -&gt; DisplayXXX (resized cropped image)
+
+
+### Matroska version indicators (DocTypeVersion and DocTypeReadVersion)
+The EBML header each Matroska file starts with contains two version number fields that inform a reading application about what to expect. These are DocTypeVersion and DocTypeReadVersion.
+
+<em>DocTypeVersion</em> must contain the highest Matroska version number of any element present in the Matroska file. For example, a file using the SimpleBlock element must have a DocTypeVersion of at least 2 while a file containing CueRelativePosition elements must have a DocTypeVersion of at least 4.
+
+The <em>DocTypeReadVersion</em> must contain the minimum version number a reading application must at least suppost properly in order to play the file back (optionally with a reduced feature set). For example, if a file contains only v2 items safe for CueRelativePosition (which is a v4 item) then DocTypeReadVersion should still be set to 2 and not 4 because evaluating CueRelativePosition is not required for standard playback -- it only makes seeking more precise if used.
+
+DocTypeVersion must always be equal to or greater than DocTypeReadVersion.
+
+A reading application supporting Matroska version <code>V</code> must not refuse to read an application with DocReadTypeVersion equal to or lower than <code>V</code> even if DocTypeVersion is greater than <code>V</code>. See also the note about <a href="#unknown-elements">unknown elements</a>.
+
+
+### Mime Types
+There is no IETF endorsed MIME type for Matroska files. But you can use the ones we have defined on our web server :
+<ul><li>.mka : Matroska audio <code>audio/x-matroska</code></li>
+<li>.mkv : Matroska video <code>video/x-matroska</code></li>
+<li>.mk3d : Matroska 3D video <code>video/x-matroska-3d</code></li>
+</ul>
+
+### Octet
+An Octet refers to a byte made of 8 bits.
+
+
+### Overlay Track
+Overlay tracks should be rendered in the same 'channel' as the track it's linked to. When content is found in such a track it is play on the rendering channel instead of the original track.
+
+
+### Position References
+The position in some elements refers to the position, in octets, from the beginning
+  of an element. The reference is the beginning of the first Segment element (= its position + the size of its ID and size fields).
+  0 = first possible position of a level 1 element in the segment. When data is spanned over mutiple
+  "linked Segments" (in the same file or in different files), the position
+  represents the accumulated offset of each Segment. For example to reference
+  a position in the third segment, the position will be: the first segment total
+  size + second segment total size + offset of the element in the third segment.
+
+
+
+### Raw Timecode
+The exact time of an object represented in nanoseconds. To find out a Block's
+  Raw Timecode, you need the Block's timecode, the <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a>, and
+  the TimecodeScale. For calculation, please see the see the <a href="notes.html#TimecodeScale">TimecodeScale
+  notes.</a>
+
+
+### Segment linking
+
+#### Hard linking
+This linking can also be called splitting. It's the operation of cutting one segment in several parts. The resulting parts should play as if it was just one part (the original segment). That means the timecode of each part follows the ones from the previous parts. The track numbers are the same. The chapters only match the current segment (unless the edition is ordered, where all parts should be in each segment). And most important, the NextUID and PrevUID points the respective segment UIDs.
+
+#### Soft linking
+Soft linking is used by codec chapters. They can reference another segment and jump on that Segment. The way the segments are described are internal to the chapter codec and unknown to the matroska level. But there are elements in the Segment Information (ChapterTranslate) that can translate a value representing a segment in the chapter codec and to the current Segment UID. All segments that could be used in a file/segment this way should be marked as members of the same family (SegmentFamily), so that the player can quickly switch from one to the other.
+
+#### Medium linking
+This kind of linking is a mix between hard and soft linking. Each segment linked is independant from the other (standalone, unlike hard linked ones). But it should be treated as a hard-link by the player. Medium linking is done through chapters using the ChapterSegmentUID element and only makes sense for ordered editions. The Segment matching the UID should be played as if it was part of the original segment (segment it's linked from) and then resume playback in the original segment. That means the timecodes of the following content should be shifted by the duration of the linked segment. As for hard-linking, the resulting segment edition should be played and considered as one.
+ 
+
+### SegmentUID
+The 128 bits UIDs must be as unique as possible. It is suggested to compute the MD5 sum of some data parts of the file (the checksum of the Cluster level if you use one). 
+
+
+### Table Columns
+The columns from the specifications table have these meanings.
+<ol><li>Element Name
+<ul><li>
+The full name of the described element.
+</li><li>
+These are the variable names used within the official EBML and Matroska software libraries.
+</li></ul></li>
+<li>Level
+<ul><li>
+The level within an EBML tree that the element may occur at.
+</li><li>
+A "+" after the number indicates that the element may occur at any level at or after the number mentioned.  A level of "3+" indicates the element may occur at levels 3, 4, 5, 6, and beyond.
+</li><li>
+With the exception of Global Elements, an element may only occur within the nearest element preceding it in level.  An element at level 3 may only have the parent that is the nearest preceding element of level 2.
+</li></ul></li>
+
+<li>EBML ID
+<ul><li>
+The Element ID displayed as octets.
+</li><li>
+The bounding with [] brackets are for aesthetic purposes to make reading easier.
+</li></ul></li>
+
+<li>Mandatory
+<ul><li>
+This element is mandatory in the file.
+</li><li>
+Mandatory elements with a default value may be left out of the file.  In the absence of a mandatory element, the element's default value is used.
+</li><li>
+A mandatory element is not written if its parent is not in the file.
+</li></ul></li>
+
+<li>Multiple
+<ul><li>
+The element may appear multiple times within its parent element
+</li><li>
+A non-multiple element may appear once in each instance of its parent.
+</li></ul></li>
+
+<li>Range
+<ul><li>
+Valid range of values to store in the element.
+</li><li>
+Two hyphenated numbers indicates a value between the two numbers inclusive.
+</li><li>
+Numeric values are expressed in decimal.
+</li><li>
+"not 0" or "&gt;0" indicates any value allowed by the element type other than zero.
+</li></ul></li>
+
+<li>Default
+<ul><li>
+The default value of the element.
+</li><li>
+When the element's parent is present and the element is not, the presence of the element is assumed virtually with the default value.  When the element's parent is not present, the element's default value is ignored.
+</li><li>
+Numeric value are expressed in decimal.
+</li></ul></li>
+
+<li>Element Type
+<ul><li>
+The form of data the element contains.
+</li><li>
+The types are the 8 basic EBML types: Signed Integer, Unsigned Integer, Float, String, UTF-8, Date, Sub elements, and Binary. No other types are allowed.
+</li></ul></li>
+
+<li>v1
+<ul><li>
+The element is contained in Matroska version 1.
+</li></ul></li>
+
+<li>v2
+<ul><li>
+The element is contained in Matroska version 2.
+</li></ul></li>
+
+<li>v3
+<ul><li>
+The element is contained in Matroska version 3.</li>
+<li>
+All currently active elements are included in Matroska version 2.
+</li>
+</ul></li>
+
+<li>v4
+<ul><li>
+The element is contained in Matroska version 4.</li>
+<li>
+v4 is the currently developed version has not been finalized yet. There may be further additions.
+</li>
+</ul></li>
+
+<li>W
+<ul><li>
+All elements in WebM (version 2).
+</li><li>
+Version 1 of WebM is officially deprecated as the only difference was the absence of SimpleBlock.
+</li></ul></li>
+
+<li>Description
+<ul><li>
+A short description of the element's purpose.
+</li></ul></li>
+</ol>
+
+
+### Timecode Types
+Absolute Timecode = Block+Cluster<br />
+  Relative Timecode = Block<br />
+  Scaled Timecode = Block+Cluster<br />
+  Raw Timecode = (Block+Cluster)*TimecodeScale*TrackTimecodeScale
+
+### TimecodeScale
+The <a href="{{site.baseurl}}/specification.html#TimecodeScale">TimecodeScale</a> is used to calculate
+  the Raw Timecode of a Block. The timecode is obtained by adding the Block's
+  timecode to the <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a>,
+  and then multiplying that result by the TimecodeScale. The result will be the
+  Block's Raw Timecode in nanoseconds. The formula for this would look like:
+(a + b) * c
+a = <a href="{{site.baseurl}}/specification.html#Block_Timecode">Block's Timecode</a><br />
+  b = <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a><br />
+  c = <a href="{{site.baseurl}}/specification.html#TimecodeScale">TimecodeScale</a>
+An example of this is, assume a <a href="{{site.baseurl}}/specification.html#Cluster">Cluster's</a> <a href="{{site.baseurl}}/specification.html#Timecode">Timecode</a> has a value of 564264, the
+  Block has a Timecode of 1233, and the timecodescale is the default of 1000000.
+
+(1233 + 564264) * 1000000 = 565497000000
+So, the Block in this example has a specific time of 565497000000 in nanoseconds.
+  In milliseconds this would be 565497ms. 
+ 
+
+
+### TimecodeScale Rounding
+
+Because the default value of TimecodeScale is 1000000, which makes each
+  integer in the Cluster and Block timecodes equal 1ms, this is the most commonly
+  used. When dealing with audio, this causes innaccuracy with where you are seeking
+  to. When the audio is combined with video, this is not an issue. For most cases
+  the the synch of audio to video does not need to be more than 1ms accurate.
+  This becomes obvious when one considers that sound will take 2-3ms to travel
+  a single meter, so distance from your speakers will have a greater effect on
+  audio/visual synch than this.
+However, when dealing with audio only files, seeking accuracy can become critical.
+  For instance, when storing a whole CD in a single track, you want to be able
+  to seek to the exact sample that a song begins at. If you seek a few sample
+  ahead or behind then a 'crack' or 'pop' may result as a few odd samples are
+  rendered. Also, when performing precise editing, it may be very useful to have
+  the audio accuracy down to a single sample. 
+It is usually true that when storing timecodes for an audio stream, the TimecodeScale
+  must have an accuracy of at least that of the audio samplerate, otherwise
+  there are rounding errors that prevent you from knowing the precise location
+  of a sample. Here's how a program has to round each timecode in order to be
+  able to recreate the sample number accurately.
+Let's assume that the application has an audio track with a sample rate of
+  44100. Which TimecodeScale should it use? As written above the TimecodeScale
+  must have at least the accuracy of the sample rate itself: 1000000000 /
+  44100 = 22675.7369614512. This value must <b>always</b> be truncated.
+  Otherwise the accuracy will not suffice. So in this example the
+  application wil use 22675 for the TimecodeScale. The application could even
+  use some lower value like 22674 which would allow it to be a little bit
+  imprecise about the original timecodes. But more about that in a minute.
+Next the application wants to write sample number 52340 and calculates the
+  timecode. This is easy. In order to calculate the Raw Timecode in ns all it
+  has to do is calculate <code>RawTimecode = round(1000000000 *
+  sample_number / sample_rate)</code>. Rounding at this stage is very
+  important! The application might skip it if it choses a slightly smaller
+  value for the TimecodeScale factor instead of the truncated one like shown
+  above. Otherwise it has to round or the results won't be reversible.  For
+  our example we get <code>RawTimecode = round(1000000000 * 52340 / 44100) =
+  round(1186848072.56236) = 1186848073</code>.
+The next step is to calculate the Absolute Timecode - that is the timecode
+  that will be stored in the Matroska file. Here the application has to divide
+  the Raw Timecode from the previous paragraph by the TimecodeScale factor and
+  round the result: <code>AbsoluteTimecode = round(RawTimecode /
+  TimecodeScale_facotr)</code> which will result in the following for our
+  example: <code>AbsoluteTimecode = round(1186848073 / 22675) =
+    round(52341.7011245866) = 52342</code>. This number is the one the
+  application has to write to the file.
+Now our file is complete, and we want to play it back with another
+  application. Its task is to find out which sample the first application
+  wrote into the file. So it starts reading the Matroska file and finds the
+  TimecodeScale factor 22675 and the audio sample rate 44100. Later it finds
+  a data block with the Absolute Timecode of 52342. But how does it get the
+  sample number from these numbers?
+First it has to calculate the Raw Timecode of the block it has just
+  read. Here's no rounding involved, just an integer multiplication:
+  <code>RawTimecode = AbsoluteTimecode * TimecodeScale_factor</code>. In our
+  example: <code>RawTimecode = 52342 * 22675 = 1186854850</code>.
+The conversion from the RawTimecode to the sample number again requires
+  rounding: <code>sample_number = round(RawTimecode * sample_rate /
+  1000000000)</code>. In our example: <code>sample_number = round(1186854850 *
+  44100 / 1000000000) = round(52340.298885) = 52340</code>. This is exactly
+  the sample number that the previous program started with.
+Some general notes for a program:
+  <ol><li>Always calculate the timestamps / sample numbers with floating point
+      numbers of at least 64bit precision (called 'double' in most modern
+      programming languages). If you're calculating with integers then make
+      sure they're 64bit long, too.</li>
+    <li>Always round if you divide. Always! If you don't you'll end up with
+      situations in which you have a timecode in the Matroska file that does
+      not correspond to the sample number that it started with. Using a
+      slightly lower timecode scale factor can help here in that it removes
+      the need for proper rounding in the conversion from sample number to Raw
+      Timecode.</li>
+  </ol>If you want some sample code for all these calculations you can have a look
+  at <a href="matroska-tcscale.c">this small C program</a>. For a given sample
+  rate it will iterate over each sample, calculate the AbsoluteTimestamp and
+  then re-calculate the sample number.
+
+
+### Track Flags
+#### Default flag
+The "default track" flag is a hint for the playback application and SHOULD always be changeable by the user. If the user wants to see or hear a track of a certain kind (audio, video, subtitles) and she hasn't chosen a specific track then the player SHOULD use the first track of that kind whose "default track" flag is set to "1". If no such track is found then the first track of this kind SHOULD be chosen.
+Only one track of a kind MAY have its "default track" flag set in a segment. If a track entry does not contain the "default track" flag element then its default value "1" is to be used.
+
+#### Forced flag
+The "forced" flag tells the playback application that it MUST display/play this track or another track of the same kind that also has its "forced" flag set. When there are multiple "forced" tracks, the player should decide on the language of the forced flag or use the default flag if no track matches the use languages. Another track of the same kind without the "forced" flag may be use simultaneously with the "forced" track (like DVD subtitles for example).
+
+
+### TrackTimecodeScale
+The <a href="{{site.baseurl}}/specification.html#TrackTimeCodeScale">TrackTimecodeScale</a> is used align tracks that would otherwise be played at different speeds. An example of this would be if you have a film that was originally recorded at 24fps video. When playing this back through a PAL broadcasting system, it is standard to speed up the film to 25fps to match the 25fps display speed of the PAL broadcasting standard. However, when broadcasting the video through NTSC, it is typical to leave the film at its original speed. If you wanted to make a single file where there was one video stream, and an audio stream used from the PAL broadcast, as well as an audio stream used from the NTSC broadcast, you would have the problem that the PAL audio stream would be 1/24th faster than the NTSC audio stream, quickly leading to problems. It is possible to stretch out the PAL audio track and reencode it at a slower speed, however when dealing with lossy audio codecs, this often results in a loss of audio quality and/or larger file sizes. 
+This is the type of problem that TrackTimecodeScale was designed to fix. Using it, the video can be played back at a speed that will synch with either the NTSC or the PAL audio stream, depending on which is being used for playback.
+To continue the above example: 
+Track 1: Video<br />
+Track 2: NTSC Audio<br />
+Track 3: PAL Audio
+Because the NTSC track is at the original speed, it will used as the default value of 1.0 for its TrackTimecodeScale. The video will also be aligned to the NTSC track with the default value of 1.0. 
+The TrackTimecodeScale value to use for the PAL track would be calculated by determining how much faster the PAL track is than the NTSC track. In this case, because we know the video for the NTSC audio is being played back at 24fps and the video for the PAL audio is being played back at 25fps, the calculation would be:
+(25 / 24) = <br />
+~ 1.
+
+
+
+
+
+ 04166666666666666667
+When writing a file that uses a non-default TrackTimecodeScale, the values of the Block's timecode are whatever they would be when normally storing the track with a default value for the TrackTimecodeScale. However, the data is interleaved a little differently. Data should be interleaved by its <a href="#Raw_Timecode">Raw Timecode</a> in the order handed back from the encoder. The Raw Timecode of a Block from a track using TrackTimecodeScale is calculated using:
+(Block's Timecode + Cluster's Timecode) * TimecodeScale * TrackTimecodeScale 
+So, a Block from the PAL track above that had a <a href="#Timecode_Types">Scaled Timecode</a> of 100 seconds would have a Raw Timecode of 104.66666667 seconds, and so would be stored in that part of the file. 
+When playing back a track using the TrackTimecodeScale, if the track is being played by itself, there is no need to scale it. From the above example, when playing the Video with the NTSC Audio, neither are scaled. However, when playing back the Video with the PAL Audio, the timecodes from the PAL Audio track are scaled using the TrackTimecodeScale, resulting in the video playing back in synch with the audio. 
+It would be possible for a player to also adjust the audio's samplerate at the same time as adjusting the timecodes if you wanted to play the two audio streams synchronously. It would also be possible to adjust the video to match the audio's speed. However, for playback, the only thing that should be counted on is the selected track(s) timecodes being adjusted if they need to be scaled.
+While the above example deals specifically with audio tracks, this element can be used to align video, audio, subtitles, or any other type of track contained in a Matroska file. 
+
+
+### Unknown elements
+
+Matroska is based upon the principal that a reading application does not have to support 100% of the specifications in order to be able to play the file. A Matroska file therefore contains <a href="#version-indicators">version indicators</a> that tell a reading application what to expect.
+
+It is possible and valid to have the version fields indicate that the file contains Matroska elements from a higher specification version number while signalling that a reading application must only support a lower version number properly in order to play it back (possibly with a reduced feature set). This implies that a reading application supporting at least Matroska version <code>V</code> reading a file whose DocTypeReadVersion field is equal to or lower than <code>V</code> must skip Matroska/EBML elements it encounters but which it does not know about if that unknown element fits into the size constraints set by the current parent element.
+
+
+### 3D and multi-planar videos
+There are 2 different ways to compress 3D videos: have each 'eye' track in a separate track and have one track have both 'eyes' combined inside (which is more efficient, compression-wise). Matroska supports both ways.
+
+For the single track variant, there is the <a href="{{site.baseurl}}/specification.html#StereoMode">StereoMode</a> element which defines how planes are assembled in the track (mono or left-right combined). Odd values of StereoMode means the left plane comes first for more convenient reading. The pixel count of the track (PixelWidth/PixelHeight) should be the raw amount of pixels (for example 3840x1080 for full HD side by side) and the DisplayWidth/Height in pixels should be the amount of pixels for one plane (1920x1080 for that full HD stream). Old stereo 3D were displayed using anaglyph (cyan and red colours separated). For compatibility with such movies, there is a value of the StereoMode that corresponds to AnaGlyph.
+There is also a "packed" mode (values 13 and 14) which consists of packing 2 frames together in a Block using lacing. The first frame is the left eye and the other frame is the right eye (or vice versa). The frames should be decoded in that order and are possibly dependent on each other (P and B frames).
+
+For separate tracks, Matroska needs to define exactly which track does what. <a href="{{site.baseurl}}/specification.html#TrackOperation">TrackOperation</a> with <a href="{{site.baseurl}}/specification.html#TrackCombinePlanes">TrackCombinePlanes</a> do that. For more details look at <a href="#TrackOperation">how TrackOperation works</a>.
+
+<em>The 3D support is still in infancy and may evolve to support more features.</em>
+
+<em>The <a href="{{site.baseurl}}/specification.html#StereoMode">StereoMode element</a> used to be part of Matroska v2 but it didn't meet the requirement for multiple tracks. There was also a bug in libmatroska prior to 0.9.0 that would save/read it as 0x53B9 instead of 0x53B8. Readers may support these legacy files by checking Matroska v2 or 0x53B9. The <a href="http://www.matroska.org/node/1/revisions/74/view#StereoMode">olders values</a> were 0: mono, 1: right eye, 2: left eye, 3: both eyes</em>
+
+
+### Track Operation
+<a href="{{site.baseurl}}/specification.html#TrackOperation">TrackOperation</a> allows combining multiple tracks to make a virtual one. It uses 2 separate system to combine tracks. One to create a 3D "composition" (left/right/background planes) and one to simplify join 2 tracks together to make a single track.
+A track created with TrackOperation is a proper track with a UID and all its flags. However the codec ID is meaningless because each "sub" track needs to be decoded by its own decoder before the "operation" is applied. The Cues corresponding to such a virtual track should be the sum of the Cues elements for each of the tracks it's composed of (when the Cues are defined per track).
+In the case of TrackJoinBlocks, the Blocks (from BlockGroup and SimpleBlock) of all the tracks should be used as if they were defined for this new virtual Track. When 2 Blocks have overlapping start or end timecodes, it's up to the underlying system to either drop some of these frames or render them the way they overlap. In the end this situation should be avoided when creating such tracks as you can never be sure of the end result on different platforms.

--- a/specification.md
+++ b/specification.md
@@ -1,0 +1,533 @@
+---
+layout: default
+---
+
+# Specifications
+
+### Status of this document
+
+This document is a work-in-progress specification defining the Matroska file format as part of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/). But since it's quite complete it is used as a reference for the development of libmatroska. Legacy versions of the specification can be found [here](/files/matroska.pdf) (PDF doc by Alexander Noé -- outdated).
+
+For a simplified diagram of the layout of a Matroska file, see the [Diagram page]({{site.baseurl}}/diagram.html).
+
+A more refined and detailed version of the EBML specifications is being [worked on here](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown).
+
+The table found below is now generated from the "source" of the Matroska specification. This [XML file](https://github.com/Matroska-Org/foundation-source/blob/master/spectool/specdata.xml) is also used to generate the semantic data used in libmatroska and libmatroska2\. We encourage anyone to use and monitor its changes so your code is spec-proof and always up to date.
+
+Note that versions 1, 2 and 3 have been finalized. Version 4 is currently work in progress. There may be further additions to v4.
+
+
+### Basis in EBML
+
+Matroska is a Document Type of EBML (Extensible Binary Meta Language). This specification is dependent on the [EBML Specification](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown). For an understanding of Matroska's EBML Schema, see in particular the sections of the EBML Specification covering [EBML Element Types](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown#ebml-element-types), [EBML Schema](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown#ebml-schema), and [EBML Structure](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown#structure).
+
+## Elements semantic
+
+A more detailed description of the column headers can be found in the [Specification Notes]({{site.baseurl}}/notes.html#Table_Columns).
+
+If you are interrested in WebM you can have a look at this page that describes what [parts of Matroska it kept](http://www.webmproject.org/code/specs/container/).
+
+*   Element Name - The full name of the described element.
+*   L - Level - The level within an EBML tree that the element may occur at. + is for a recursive level (can be its own child). g: global element (can be found at any level)
+*   EBML ID - The Element ID displayed as octets.
+*   Ma - Mandatory - This element is mandatory in the file (abbreviated as »mand.«).
+*   Mu - Multiple - The element may appear multiple times within its parent element (abbreviated as »mult.«).
+*   Rng - Range - Valid range of values to store in the element.
+*   Default - The default value of the element.
+*   T - Element Type - The form of data the element contains. m: Master, u: unsigned int, i: signed integer, s: string, 8: UTF-8 string, b: binary, f: float, d: date
+*   1 - The element is contained in Matroska version 1.
+*   2 - The element is contained in Matroska version 2.
+*   3 - The element is contained in Matroska version 3.
+*   4 - The element is contained in Matroska version 4 (v4 is still work in progress; further additions are possible).
+*   W - All elements available for use in WebM.
+*   Description - A short description of the element's purpose.
+
+
+
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> |                Description           |
+| EBML Header |
+| EBML | 0 | [1A][45][DF][A3] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Set the EBML characteristics of the data to follow. Each EBML document has to start with this. |
+| EBMLVersion | 1 | [42][86] | mand. | - | - | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The version of EBML parser used to create the file. |
+| EBMLReadVersion | 1 | [42][F7] | mand. | - | - | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The minimum EBML version a parser has to support to read this file. |
+| EBMLMaxIDLength | 1 | [42][F2] | mand. | - | - | 4 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The maximum length of the IDs you'll find in this file (4 or less in Matroska). |
+| EBMLMaxSizeLength | 1 | [42][F3] | mand. | - | - | 8 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid. |
+| DocType | 1 | [42][82] | mand. | - | - | matroska | <abbr title="String">s</abbr> | * | * | * | * | * | A string that describes the type of document that follows this EBML header. 'matroska' in our case or 'webm' for webm files. |
+| DocTypeVersion | 1 | [42][87] | mand. | - | - | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The version of DocType interpreter used to create the file. |
+| DocTypeReadVersion | 1 | [42][85] | mand. | - | - | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The minimum DocType version an interpreter has to support to read this file. |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Global elements (used everywhere in the format) |
+| Void | g | [EC] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | * | Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use. |
+| CRC-32 | g | [BF] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | The CRC is computed on all the data of the Master element it's in. The CRC element should be the first in it's parent master for easier reading. All level 1 elements should include a CRC-32\. The CRC in use is the IEEE CRC32 Little Endian |
+| SignatureSlot | g | [1B][53][86][67] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | Contain signature of some (coming) elements in the stream. |
+| SignatureAlgo | 1 | [7E][8A] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | Signature algorithm used (1=RSA, 2=elliptic). |
+| SignatureHash | 1 | [7E][9A] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | Hash algorithm used (1=SHA1-160, 2=MD5). |
+| SignaturePublicKey | 1 | [7E][A5] | - | - | - | - | <abbr title="Binary">b</abbr> | The public key to use with the algorithm (in the case of a PKI-based signature). |
+| Signature | 1 | [7E][B5] | - | - | - | - | <abbr title="Binary">b</abbr> | The signature of the data (until a new. |
+| SignatureElements | 1 | [7E][5B] | - | - | - | - | <abbr title="Master Elements">m</abbr> | Contains elements that will be used to compute the signature. |
+| SignatureElementList | 2 | [7E][7B] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | A list consists of a number of consecutive elements that represent one case where data is used in signature. Ex: _Cluster|Block|BlockAdditional_ means that the BlockAdditional of all Blocks in all Clusters is used for encryption. |
+| SignedElement | 3 | [65][32] | - | mult. | - | - | <abbr title="Binary">b</abbr> | An element ID whose data will be used to compute the signature. |
+
+The default values defined for the EBML header correspond to the values for a Matroska stream/file. When parsing the EBML header the default values are different, irrespective of the DocType defined.
+
+*   EBMLMaxIDLength is 4: IDs in the EBML header cannot be longer than 4 octets.
+*   EBMLMaxSizeLength is 4: Length of IDs in the EBML header cannot be longer than 4 octets.
+
+
+
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Segment |
+| Segment | 0 | [18][53][80][67] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | This element contains all other top-level (level 1) elements. Typically a Matroska file is composed of 1 segment. |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Meta Seek Information |
+| SeekHead | 1 | [11][4D][9B][74] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains the [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of other level 1 elements. |
+| Seek | 2 | [4D][BB] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains a single seek entry to an EBML element. |
+| SeekID | 3 | [53][AB] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | * | The binary ID corresponding to the element name. |
+| SeekPosition | 3 | [53][AC] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the element in the segment in octets (0 = first level 1 element). |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Segment Information |
+| Info | 1 | [15][49][A9][66] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains miscellaneous general information and statistics on the file. |
+| SegmentUID | 2 | [73][A4] | - | - | not 0 | - | <abbr title="Binary">b</abbr> | * | * | * | * | A randomly generated unique ID to identify the current segment between many others (128 bits). |
+| SegmentFilename | 2 | [73][84] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | A filename corresponding to this segment. |
+| PrevUID | 2 | [3C][B9][23] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | A unique ID to identify the previous chained segment (128 bits). |
+| PrevFilename | 2 | [3C][83][AB] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | An escaped filename corresponding to the previous segment. |
+| NextUID | 2 | [3E][B9][23] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | A unique ID to identify the next chained segment (128 bits). |
+| NextFilename | 2 | [3E][83][BB] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | An escaped filename corresponding to the next segment. |
+| SegmentFamily | 2 | [44][44] | - | mult. | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | A randomly generated unique ID that all segments related to each other must use (128 bits). |
+| ChapterTranslate | 2 | [69][24] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | A tuple of corresponding ID used by chapter codecs to represent this segment. |
+| ChapterTranslateEditionUID | 3 | [69][FC] | - | mult. | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify an edition UID on which this correspondance applies. When not specified, it means for all editions found in the segment. |
+| ChapterTranslateCodec | 3 | [69][BF] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The [chapter codec](http://www.matroska.org/technical/specs/index.html#ChapProcessCodecID) using this ID (0: Matroska Script, 1: DVD-menu). |
+| ChapterTranslateID | 3 | [69][A5] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | The binary value used to represent this segment in the chapter codec data. The format depends on the [ChapProcessCodecID](http://www.matroska.org/technical/specs/chapters/index.html#ChapProcessCodecID) used. |
+| TimecodeScale | 2 | [2A][D7][B1] | mand. | - | - | 1000000 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Timestamp scale in nanoseconds (1.000.000 means all timestamps in the segment are expressed in milliseconds). |
+| Duration | 2 | [44][89] | - | - | > 0 | - | <abbr title="Float">f</abbr> | * | * | * | * | * | Duration of the segment (based on TimecodeScale). |
+| DateUTC | 2 | [44][61] | - | - | - | - | <abbr title="Date">d</abbr> | * | * | * | * | * | Date of the origin of timestamp (value 0), i.e. production date. |
+| Title | 2 | [7B][A9] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | General name of the segment. |
+| MuxingApp | 2 | [4D][80] | mand. | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | * | Muxing application or library ("libmatroska-0.4.3"). |
+| WritingApp | 2 | [57][41] | mand. | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | * | Writing application ("mkvmerge-0.3.3"). |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Cluster |
+| Cluster | 1 | [1F][43][B6][75] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | The lower level element containing the (monolithic) Block structure. |
+| Timecode | 2 | [E7] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Absolute timestamp of the cluster (based on TimecodeScale). |
+| SilentTracks | 2 | [58][54] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | The list of tracks that are not used in that part of the stream. It is useful when using overlay tracks on seeking. Then you should decide what track to use. |
+| SilentTrackNumber | 3 | [58][D7] | - | mult. | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | One of the track number that are not used from now on in the stream. It could change later if not specified as silent in a further Cluster. |
+| Position | 2 | [A7] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The [Position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the Cluster in the segment (0 in live broadcast streams). It might help to resynchronise offset on damaged streams. |
+| PrevSize | 2 | [AB] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Size of the previous Cluster, in octets. Can be useful for backward playing. |
+| SimpleBlock | 2 | [A3] | - | mult. | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Similar to [Block](http://www.matroska.org/technical/specs/index.html#Block) but without all the extra information, mostly used to reduced overhead when no extra feature is needed. (see [SimpleBlock Structure](http://www.matroska.org/technical/specs/index.html#simpleblock_structure)) |
+| BlockGroup | 2 | [A0] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Basic container of information containing a single Block or BlockVirtual, and information specific to that Block/VirtualBlock. |
+| Block | 3 | [A1] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | * | Block containing the actual data to be rendered and a timestamp relative to the Cluster Timecode. (see [Block Structure](http://www.matroska.org/technical/specs/index.html#block_structure)) |
+| BlockVirtual | 3 | [A2] | - | - | - | - | <abbr title="Binary">b</abbr> | A Block with no data. It must be stored in the stream at the place the real Block should be in display order. (see [Block Virtual](http://www.matroska.org/technical/specs/index.html#block_virtual)) |
+| BlockAdditions | 3 | [75][A1] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contain additional blocks to complete the main one. An EBML parser that has no knowledge of the Block structure could still see and use/skip these data. |
+| BlockMore | 4 | [A6] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contain the BlockAdditional and some parameters. |
+| BlockAddID | 5 | [EE] | mand. | - | not 0 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | An ID to identify the BlockAdditional level. |
+| BlockAdditional | 5 | [A5] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Interpreted by the codec as it wishes (using the BlockAddID). |
+| BlockDuration | 3 | [9B] | - | - | - | DefaultDuration | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The duration of the Block (based on TimecodeScale). This element is mandatory when DefaultDuration is set for the track (but can be omitted as other default values). When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order). This element can be useful at the end of a Track (as there is not other Block available), or when there is a break in a track like for subtitle tracks. When set to 0 that means the frame is not a keyframe. |
+| ReferencePriority | 3 | [FA] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | This frame is referenced and has the specified cache priority. In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced. |
+| ReferenceBlock | 3 | [FB] | - | mult. | - | - | <abbr title="Signed Integer">i</abbr> | * | * | * | * | * | Timestamp of another frame used as a reference (ie: B or P frame). The timestamp is relative to the block it's attached to. |
+| ReferenceVirtual | 3 | [FD] | - | - | - | - | <abbr title="Signed Integer">i</abbr> | Relative [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the data that should be in position of the virtual block. |
+| CodecState | 3 | [A4] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | The new codec state to use. Data interpretation is private to the codec. This information should always be referenced by a seek entry. |
+| DiscardPadding | 3 | [75][A2] | - | - | - | - | <abbr title="Signed Integer">i</abbr> | * | * | Duration in nanoseconds of the silent data added to the Block (padding at the end of the Block for positive value, at the beginning of the Block for negative value). The duration of DiscardPadding is not calculated in the duration of the TrackEntry and should be discarded during playback. |
+| Slices | 3 | [8E] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains slices description. |
+| TimeSlice | 4 | [E8] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains extra time information about the data contained in the Block. While there are a few files in the wild with this element, it is no longer in use and has been deprecated. Being able to interpret this element is not required for playback. |
+| LaceNumber | 5 | [CC] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The reverse number of the frame in the lace (0 is the last frame, 1 is the next to last, etc). While there are a few files in the wild with this element, it is no longer in use and has been deprecated. Being able to interpret this element is not required for playback. |
+| FrameNumber | 5 | [CD] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | The number of the frame to generate from this lace with this delay (allow you to generate many frames from the same Block/Frame). |
+| BlockAdditionID | 5 | [CB] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | The ID of the BlockAdditional element (0 is the main Block). |
+| Delay | 5 | [CE] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | The (scaled) delay to apply to the element. |
+| SliceDuration | 5 | [CF] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | The (scaled) duration to apply to the element. |
+| ReferenceFrame | 3 | [C8] | - | - | - | - | <abbr title="Master Elements">m</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| ReferenceOffset | 4 | [C9] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| ReferenceTimeCode | 4 | [CA] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| EncryptedBlock | 2 | [AF] | - | mult. | - | - | <abbr title="Binary">b</abbr> | Similar to [SimpleBlock](http://www.matroska.org/technical/specs/index.html#SimpleBlock) but the data inside the Block are Transformed (encrypt and/or signed). (see [EncryptedBlock Structure](http://www.matroska.org/technical/specs/index.html#encryptedblock_structure)) |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+
+
+| Track |
+| Tracks | 1 | [16][54][AE][6B] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | A top-level block of information with many tracks described. |
+| TrackEntry | 2 | [AE] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Describes a track with all elements. |
+| TrackNumber | 3 | [D7] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The track number as used in the Block Header (using more than 127 tracks is not encouraged, though the design allows an unlimited number). |
+| TrackUID | 3 | [73][C5] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | A unique ID to identify the Track. This should be kept the same when making a direct stream copy of the Track to another file. |
+| TrackType | 3 | [83] | mand. | - | 1-254 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | A set of track types coded on 8 bits (1: video, 2: audio, 3: complex, 0x10: logo, 0x11: subtitle, 0x12: buttons, 0x20: control). |
+| FlagEnabled | 3 | [B9] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Set if the track is usable. (1 bit) |
+| FlagDefault | 3 | [88] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Set if that track (audio, video or subs) SHOULD be active if no language found matches the user preference. (1 bit) |
+| FlagForced | 3 | [55][AA] | mand. | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Set if that track MUST be active during playback. There can be many forced track for a kind (audio, video or subs), the player should select the one which language matches the user preference or the default + forced track. Overlay MAY happen between a forced and non-forced track of the same kind. (1 bit) |
+| FlagLacing | 3 | [9C] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Set if the track may contain blocks using lacing. (1 bit) |
+| MinCache | 3 | [6D][E7] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The minimum number of frames a player should be able to cache during playback. If set to 0, the reference pseudo-cache system is not used. |
+| MaxCache | 3 | [6D][F8] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The maximum cache size required to store referenced frames in and the current frame. 0 means no cache is needed. |
+| DefaultDuration | 3 | [23][E3][83] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Number of nanoseconds (not scaled via TimecodeScale) per frame ('frame' in the Matroska sense -- one element put into a (Simple)Block). |
+| DefaultDecodedFieldDuration | 3 | [23][4E][7A] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | The period in nanoseconds (not scaled by TimcodeScale) between two successive fields at the output of the decoding process (see [the notes](http://www.matroska.org/technical/specs/notes.html#DefaultDecodedFieldDuration)) |
+| TrackTimecodeScale | 3 | [23][31][4F] | mand. | - | > 0 | 1.0 | <abbr title="Float">f</abbr> | * | * | * | DEPRECATED, DO NOT USE. The scale to apply on this track to work at normal speed in relation with other tracks (mostly used to adjust video speed when the audio length differs). |
+| TrackOffset | 3 | [53][7F] | - | - | - | 0 | <abbr title="Signed Integer">i</abbr> | A value to add to the Block's Timestamp. This can be used to adjust the playback offset of a track. |
+| MaxBlockAdditionID | 3 | [55][EE] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The maximum value of [BlockAddID](http://www.matroska.org/technical/specs/index.html#BlockAddID). A value 0 means there is no [BlockAdditions](http://www.matroska.org/technical/specs/index.html#BlockAdditions) for this track. |
+| Name | 3 | [53][6E] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | * | A human-readable track name. |
+| Language | 3 | [22][B5][9C] | - | - | - | eng | <abbr title="String">s</abbr> | * | * | * | * | * | Specifies the language of the track in the [Matroska languages form](http://www.matroska.org/technical/specs/index.html#languages). |
+| CodecID | 3 | [86] | mand. | - | - | - | <abbr title="String">s</abbr> | * | * | * | * | * | An ID corresponding to the codec, see the [codec page](http://www.matroska.org/technical/specs/codecid/index.html) for more info. |
+| CodecPrivate | 3 | [63][A2] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | * | Private data only known to the codec. |
+| CodecName | 3 | [25][86][88] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | * | A human-readable string specifying the codec. |
+| AttachmentLink | 3 | [74][46] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The UID of an attachment that is used by this codec. |
+| CodecSettings | 3 | [3A][96][97] | - | - | - | - | <abbr title="UTF-8">8</abbr> | A string describing the encoding setting used. |
+| CodecInfoURL | 3 | [3B][40][40] | - | mult. | - | - | <abbr title="String">s</abbr> | A URL to find information about the codec used. |
+| CodecDownloadURL | 3 | [26][B2][40] | - | mult. | - | - | <abbr title="String">s</abbr> | A URL to download about the codec used. |
+| CodecDecodeAll | 3 | [AA] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | The codec can decode potentially damaged data (1 bit). |
+| TrackOverlay | 3 | [6F][AB] | - | mult. | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify that this track is an overlay track for the Track specified (in the u-integer). That means when this track has a gap (see [SilentTracks](http://www.matroska.org/technical/specs/index.html#SilentTracks)) the overlay track should be used instead. The order of multiple TrackOverlay matters, the first one is the one that should be used. If not found it should be the second, etc. |
+| CodecDelay | 3 | [56][AA] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | CodecDelay is The codec-built-in delay in nanoseconds. This value must be subtracted from each block timestamp in order to get the actual timestamp. The value should be small so the muxing of tracks with the same actual timestamp are in the same Cluster. |
+| SeekPreRoll | 3 | [56][BB] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | After a discontinuity, SeekPreRoll is the duration in nanoseconds of the data the decoder must decode before the decoded data is valid. |
+| TrackTranslate | 3 | [66][24] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | The track identification for the given Chapter Codec. |
+| TrackTranslateEditionUID | 4 | [66][FC] | - | mult. | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify an edition UID on which this translation applies. When not specified, it means for all editions found in the segment. |
+| TrackTranslateCodec | 4 | [66][BF] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The [chapter codec](http://www.matroska.org/technical/specs/index.html#ChapProcessCodecID) using this ID (0: Matroska Script, 1: DVD-menu). |
+| TrackTranslateTrackID | 4 | [66][A5] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | The binary value used to represent this track in the chapter codec data. The format depends on the [ChapProcessCodecID](http://www.matroska.org/technical/specs/index.html#ChapProcessCodecID) used. |
+| Video | 3 | [E0] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Video settings. |
+| FlagInterlaced | 4 | [9A] | mand. | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Set if the video is interlaced. (1 bit) |
+| StereoMode | 4 | [53][B8] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | Stereo-3D video mode (0: mono, 1: side by side (left eye is first), 2: top-bottom (right eye is first), 3: top-bottom (left eye is first), 4: checkboard (right is first), 5: checkboard (left is first), 6: row interleaved (right is first), 7: row interleaved (left is first), 8: column interleaved (right is first), 9: column interleaved (left is first), 10: anaglyph (cyan/red), 11: side by side (right eye is first), 12: anaglyph (green/magenta), 13 both eyes laced in one Block (left eye is first), 14 both eyes laced in one Block (right eye is first)) . There are some more details on [3D support in the Specification Notes](http://www.matroska.org/technical/specs/notes.html#3D). |
+| AlphaMode | 4 | [53][C0] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | Alpha Video Mode. Presence of this element indicates that the BlockAdditional element could contain Alpha data. |
+| OldStereoMode | 4 | [53][B9] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | DEPRECATED, DO NOT USE. Bogus StereoMode value used in old versions of libmatroska. (0: mono, 1: right eye, 2: left eye, 3: both eyes). |
+| PixelWidth | 4 | [B0] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Width of the encoded video frames in pixels. |
+| PixelHeight | 4 | [BA] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Height of the encoded video frames in pixels. |
+| PixelCropBottom | 4 | [54][AA] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The number of video pixels to remove at the bottom of the image (for HDTV content). |
+| PixelCropTop | 4 | [54][BB] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The number of video pixels to remove at the top of the image. |
+| PixelCropLeft | 4 | [54][CC] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The number of video pixels to remove on the left of the image. |
+| PixelCropRight | 4 | [54][DD] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The number of video pixels to remove on the right of the image. |
+| DisplayWidth | 4 | [54][B0] | - | - | not 0 | PixelWidth | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Width of the video frames to display. The default value is only valid when [DisplayUnit](http://www.matroska.org/technical/specs/index.html#DisplayUnit) is 0. |
+| DisplayHeight | 4 | [54][BA] | - | - | not 0 | PixelHeight | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Height of the video frames to display. The default value is only valid when [DisplayUnit](http://www.matroska.org/technical/specs/index.html#DisplayUnit) is 0. |
+| DisplayUnit | 4 | [54][B2] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | How DisplayWidth & DisplayHeight should be interpreted (0: pixels, 1: centimeters, 2: inches, 3: Display Aspect Ratio). |
+| AspectRatioType | 4 | [54][B3] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Specify the possible modifications to the aspect ratio (0: free resizing, 1: keep aspect ratio, 2: fixed). |
+| ColourSpace | 4 | [2E][B5][24] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Same value as in AVI (32 bits). |
+| GammaValue | 4 | [2F][B5][23] | - | - | > 0 | - | <abbr title="Float">f</abbr> | Gamma Value. |
+| FrameRate | 4 | [23][83][E3] | - | - | > 0 | - | <abbr title="Float">f</abbr> | Number of frames per second. **Informational** only. |
+| Audio | 3 | [E1] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Audio settings. |
+| SamplingFrequency | 4 | [B5] | mand. | - | > 0 | 8000.0 | <abbr title="Float">f</abbr> | * | * | * | * | * | Sampling frequency in Hz. |
+| OutputSamplingFrequency | 4 | [78][B5] | - | - | > 0 | SamplingFrequency | <abbr title="Float">f</abbr> | * | * | * | * | * | Real output sampling frequency in Hz (used for SBR techniques). |
+| Channels | 4 | [9F] | mand. | - | not 0 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Numbers of channels in the track. |
+| ChannelPositions | 4 | [7D][7B] | - | - | - | - | <abbr title="Binary">b</abbr> | Table of horizontal angles for each successive channel, see [appendix](http://www.matroska.org/technical/specs/index.html#channelposition). |
+| BitDepth | 4 | [62][64] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Bits per sample, mostly used for PCM. |
+| TrackOperation | 3 | [E2] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | Operation that needs to be applied on tracks to create this virtual track. For more details [look at the Specification Notes](http://www.matroska.org/technical/specs/notes.html#TrackOperation) on the subject. |
+| TrackCombinePlanes | 4 | [E3] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | Contains the list of all video plane tracks that need to be combined to create this 3D track |
+| TrackPlane | 5 | [E4] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | Contains a video plane track that need to be combined to create this 3D track |
+| TrackPlaneUID | 6 | [E5] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | The trackUID number of the track representing the plane. |
+| TrackPlaneType | 6 | [E6] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | The kind of plane this track corresponds to (0: left eye, 1: right eye, 2: background). |
+| TrackJoinBlocks | 4 | [E9] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | Contains the list of all tracks whose Blocks need to be combined to create this virtual track |
+| TrackJoinUID | 5 | [ED] | mand. | mult. | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | The trackUID number of a track whose blocks are used to create this virtual track. |
+| TrickTrackUID | 3 | [C0] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| TrickTrackSegmentUID | 3 | [C1] | - | - | - | - | <abbr title="Binary">b</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| TrickTrackFlag | 3 | [C6] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| TrickMasterTrackUID | 3 | [C7] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| TrickMasterTrackSegmentUID | 3 | [C4] | - | - | - | - | <abbr title="Binary">b</abbr> | [DivX trick track extenstions](http://developer.divx.com/docs/divx_plus_hd/format_features/Smooth_FF_RW) |
+| ContentEncodings | 3 | [6D][80] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Settings for several content encoding mechanisms like compression or encryption. |
+| ContentEncoding | 4 | [62][40] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Settings for one content encoding like compression or encryption. |
+| ContentEncodingOrder | 5 | [50][31] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Tells when this modification was used during encoding/muxing starting with 0 and counting upwards. The decoder/demuxer has to start with the highest order number it finds and work its way down. This value has to be unique over all ContentEncodingOrder elements in the segment. |
+| ContentEncodingScope | 5 | [50][32] | mand. | - | not 0 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A bit field that describes which elements have been modified in this way. Values (big endian) can be OR'ed. Possible values: 1 - all frame contents, 2 - the track's private data, 4 - the next ContentEncoding (next ContentEncodingOrder. Either the data inside ContentCompression and/or ContentEncryption) |
+| ContentEncodingType | 5 | [50][33] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A value describing what kind of transformation has been done. Possible values: 0 - compression, 1 - encryption |
+| ContentCompression | 5 | [50][34] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Settings describing the compression used. Must be present if the value of ContentEncodingType is 0 and absent otherwise. Each block must be decompressable even if no previous block is available in order not to prevent seeking. |
+| ContentCompAlgo | 6 | [42][54] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The compression algorithm used. Algorithms that have been specified so far are: 0 - zlib, ~~1 - bzlib,~~ ~~2 - lzo1x~~
+3 - Header Stripping |
+| ContentCompSettings | 6 | [42][55] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Settings that might be needed by the decompressor. For Header Stripping (ContentCompAlgo=3), the bytes that were removed from the beggining of each frames of the track. |
+| ContentEncryption | 5 | [50][35] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Settings describing the encryption used. Must be present if the value of ContentEncodingType is 1 and absent otherwise. |
+| ContentEncAlgo | 6 | [47][E1] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The encryption algorithm used. The value '0' means that the contents have not been encrypted but only signed. Predefined values: 1 - DES, 2 - 3DES, 3 - Twofish, 4 - Blowfish, 5 - AES |
+| ContentEncKeyID | 6 | [47][E2] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | For public key algorithms this is the ID of the public key the the data was encrypted with. |
+| ContentSignature | 6 | [47][E3] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | A cryptographic signature of the contents. |
+| ContentSigKeyID | 6 | [47][E4] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | This is the ID of the private key the data was signed with. |
+| ContentSigAlgo | 6 | [47][E5] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The algorithm used for the signature. A value of '0' means that the contents have not been signed but only encrypted. Predefined values: 1 - RSA |
+| ContentSigHashAlgo | 6 | [47][E6] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The hash algorithm used for the signature. A value of '0' means that the contents have not been signed but only encrypted. Predefined values: 1 - SHA1-160 2 - MD5 |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Cueing Data |
+| Cues | 1 | [1C][53][BB][6B] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | A top-level element to speed seeking access. All entries are local to the segment. Should be mandatory for non ["live" streams](http://www.matroska.org/technical/streaming/index.hmtl). |
+| CuePoint | 2 | [BB] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains all information relative to a seek point in the segment. |
+| CueTime | 3 | [B3] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Absolute timestamp according to the segment time base. |
+| CueTrackPositions | 3 | [B7] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contain positions for different tracks corresponding to the timestamp. |
+| CueTrack | 4 | [F7] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The track for which a position is given. |
+| CueClusterPosition | 4 | [F1] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | The [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the Cluster containing the required Block. |
+| CueRelativePosition | 4 | [F0] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | The relative position of the referenced block inside the cluster with 0 being the first possible position for an element inside that cluster. |
+| CueDuration | 4 | [B2] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | The duration of the block according to the segment time base. If missing the track's DefaultDuration does not apply and no duration information is available in terms of the cues. |
+| CueBlockNumber | 4 | [53][78] | - | - | not 0 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Number of the Block in the specified Cluster. |
+| CueCodecState | 4 | [EA] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | The [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the Codec State corresponding to this Cue element. 0 means that the data is taken from the initial Track Entry. |
+| CueReference | 4 | [DB] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | The Clusters containing the required referenced Blocks. |
+| CueRefTime | 5 | [96] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | Timestamp of the referenced Block. |
+| CueRefCluster | 5 | [97] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | The [Position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the Cluster containing the referenced Block. |
+| CueRefNumber | 5 | [53][5F] | - | - | not 0 | 1 | <abbr title="Unsigned Integer">u</abbr> | Number of the referenced Block of Track X in the specified Cluster. |
+| CueRefCodecState | 5 | [EB] | - | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | The [position](http://www.matroska.org/technical/specs/notes.html#Position_References) of the Codec State corresponding to this referenced element. 0 means that the data is taken from the initial Track Entry. |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Attachment |
+| Attachments | 1 | [19][41][A4][69] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contain attached files. |
+| AttachedFile | 2 | [61][A7] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | An attached file. |
+| FileDescription | 3 | [46][7E] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | A human-friendly name for the attached file. |
+| FileName | 3 | [46][6E] | mand. | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | Filename of the attached file. |
+| FileMimeType | 3 | [46][60] | mand. | - | - | - | <abbr title="String">s</abbr> | * | * | * | * | MIME type of the file. |
+| FileData | 3 | [46][5C] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | The data of the file. |
+| FileUID | 3 | [46][AE] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Unique ID representing the file, as random as possible. |
+| FileReferral | 3 | [46][75] | - | - | - | - | <abbr title="Binary">b</abbr> | A binary value that a track/codec can refer to when the attachment is needed. |
+| FileUsedStartTime | 3 | [46][61] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX font extension](http://developer.divx.com/docs/divx_plus_hd/format_features/World_Fonts) |
+| FileUsedEndTime | 3 | [46][62] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | [DivX font extension](http://developer.divx.com/docs/divx_plus_hd/format_features/World_Fonts) |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Chapters |
+| Chapters | 1 | [10][43][A7][70] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | A system to define basic menus and partition data. For more detailed information, look at the [Chapters Explanation](http://www.matroska.org/technical/specs/chapters/index.html). |
+| EditionEntry | 2 | [45][B9] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains all information about a segment edition. |
+| EditionUID | 3 | [45][BC] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A unique ID to identify the edition. It's useful for tagging an edition. |
+| EditionFlagHidden | 3 | [45][BD] | mand. | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | If an edition is hidden (1), it should not be available to the user interface (but still to Control Tracks; see [flag notes](http://www.matroska.org/technical/specs/chapters/index.html#flags)). (1 bit) |
+| EditionFlagDefault | 3 | [45][DB] | mand. | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | If a flag is set (1) the edition should be used as the default one. (1 bit) |
+| EditionFlagOrdered | 3 | [45][DD] | - | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify if the chapters can be defined multiple times and the order to play them is enforced. (1 bit) |
+| ChapterAtom | 3+ | [B6] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains the atom information to use as the chapter atom (apply to all tracks). |
+| ChapterUID | 4 | [73][C4] | mand. | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | A unique ID to identify the Chapter. |
+| ChapterStringUID | 4 | [56][54] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | A unique string ID to identify the Chapter. Use for [WebVTT cue identifier storage](http://dev.w3.org/html5/webvtt/#webvtt-cue-identifier). |
+| ChapterTimeStart | 4 | [91] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | * | Timestamp of the start of Chapter (not scaled). |
+| ChapterTimeEnd | 4 | [92] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Timestamp of the end of Chapter (timestamp excluded, not scaled). |
+| ChapterFlagHidden | 4 | [98] | mand. | - | 0-1 | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | If a chapter is hidden (1), it should not be available to the user interface (but still to Control Tracks; see [flag notes](http://www.matroska.org/technical/specs/chapters/index.html#flags)). (1 bit) |
+| ChapterFlagEnabled | 4 | [45][98] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify wether the chapter is enabled. It can be enabled/disabled by a Control Track. When disabled, the movie should skip all the content between the TimeStart and TimeEnd of this chapter (see [flag notes](http://www.matroska.org/technical/specs/chapters/index.html#flags)). (1 bit) |
+| ChapterSegmentUID | 4 | [6E][67] | - | - | >0 | - | <abbr title="Binary">b</abbr> | * | * | * | * | A segment to play in place of this chapter. Edition ChapterSegmentEditionUID should be used for this segment, otherwise no edition is used. |
+| ChapterSegmentEditionUID | 4 | [6E][BC] | - | - | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | The EditionUID to play from the segment linked in ChapterSegmentUID. |
+| ChapterPhysicalEquiv | 4 | [63][C3] | - | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Specify the physical equivalent of this ChapterAtom like "DVD" (60) or "SIDE" (50), see [complete list of values](http://www.matroska.org/technical/specs/index.html#physical). |
+| ChapterTrack | 4 | [8F] | - | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | List of tracks on which the chapter applies. If this element is not present, all tracks apply |
+| ChapterTrackNumber | 5 | [89] | mand. | mult. | not 0 | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | UID of the Track to apply this chapter too. In the absense of a control track, choosing this chapter will select the listed Tracks and deselect unlisted tracks. Absense of this element indicates that the Chapter should be applied to any currently used Tracks. |
+| ChapterDisplay | 4 | [80] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | * | Contains all possible strings to use for the chapter display. |
+| ChapString | 5 | [85] | mand. | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | * | Contains the string to use as the chapter atom. |
+| ChapLanguage | 5 | [43][7C] | mand. | mult. | - | eng | <abbr title="String">s</abbr> | * | * | * | * | * | The languages corresponding to the string, in the [bibliographic ISO-639-2 form](http://www.loc.gov/standards/iso639-2/php/English_list.php). |
+| ChapCountry | 5 | [43][7E] | - | mult. | - | - | <abbr title="String">s</abbr> | * | * | * | * | The countries corresponding to the string, same 2 octets as in [Internet domains](http://www.iana.org/cctld/cctld-whois.htm). |
+| ChapProcess | 4 | [69][44] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contains all the commands associated to the Atom. |
+| ChapProcessCodecID | 5 | [69][55] | mand. | - | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Contains the type of the codec used for the processing. A value of 0 means native Matroska processing (to be defined), a value of 1 means the [DVD](http://www.matroska.org/technical/specs/chapters/index.html#dvd) command set is used. More codec IDs can be added later. |
+| ChapProcessPrivate | 5 | [45][0D] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Some optional data attached to the ChapProcessCodecID information. [For ChapProcessCodecID = 1](http://www.matroska.org/technical/specs/chapters/index.html#dvd), it is the "DVD level" equivalent. |
+| ChapProcessCommand | 5 | [69][11] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contains all the commands associated to the Atom. |
+| ChapProcessTime | 6 | [69][22] | mand. | - | - | - | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Defines when the process command should be handled (0: during the whole chapter, 1: before starting playback, 2: after playback of the chapter). |
+| ChapProcessData | 6 | [69][33] | mand. | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | Contains the command information. The data should be interpreted depending on the ChapProcessCodecID value. [For ChapProcessCodecID = 1](http://www.matroska.org/technical/specs/chapters/index.html#dvd), the data correspond to the binary DVD cell pre/post commands. |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+| Tagging |
+| Tags | 1 | [12][54][C3][67] | - | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Element containing elements specific to Tracks/Chapters. A list of valid tags can be found [here.](http://www.matroska.org/technical/specs/tagging/index.html) |
+| Tag | 2 | [73][73] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Element containing elements specific to Tracks/Chapters. |
+| Targets | 3 | [63][C0] | mand. | - | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contain all UIDs where the specified meta data apply. It is empty to describe everything in the segment. |
+| TargetTypeValue | 4 | [68][CA] | - | - | - | 50 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A number to indicate the logical level of the target (see [TargetType](http://www.matroska.org/technical/specs/tagging/index.html#targettypes)). |
+| TargetType | 4 | [63][CA] | - | - | - | - | <abbr title="String">s</abbr> | * | * | * | * | An **informational** string that can be used to display the logical level of the target like "ALBUM", "TRACK", "MOVIE", "CHAPTER", etc (see [TargetType](http://www.matroska.org/technical/specs/tagging/index.html#targettypes)). |
+| TagTrackUID | 4 | [63][C5] | - | mult. | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A unique ID to identify the Track(s) the tags belong to. If the value is 0 at this level, the tags apply to all tracks in the Segment. |
+| TagEditionUID | 4 | [63][C9] | - | mult. | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A unique ID to identify the EditionEntry(s) the tags belong to. If the value is 0 at this level, the tags apply to all editions in the Segment. |
+| TagChapterUID | 4 | [63][C4] | - | mult. | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A unique ID to identify the Chapter(s) the tags belong to. If the value is 0 at this level, the tags apply to all chapters in the Segment. |
+| TagAttachmentUID | 4 | [63][C6] | - | mult. | - | 0 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | A unique ID to identify the Attachment(s) the tags belong to. If the value is 0 at this level, the tags apply to all the attachments in the Segment. |
+| SimpleTag | 3+ | [67][C8] | mand. | mult. | - | - | <abbr title="Master Elements">m</abbr> | * | * | * | * | Contains general information about the target. |
+| TagName | 4 | [45][A3] | mand. | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | The name of the Tag that is going to be stored. |
+| TagLanguage | 4 | [44][7A] | mand. | - | - | und | <abbr title="String">s</abbr> | * | * | * | * | Specifies the language of the tag specified, in the [Matroska languages form](http://www.matroska.org/technical/specs/index.html#languages). |
+| TagDefault | 4 | [44][84] | mand. | - | 0-1 | 1 | <abbr title="Unsigned Integer">u</abbr> | * | * | * | * | Indication to know if this is the default/original language to use for the given tag. (1 bit) |
+| TagString | 4 | [44][87] | - | - | - | - | <abbr title="UTF-8">8</abbr> | * | * | * | * | The value of the Tag. |
+| TagBinary | 4 | [44][85] | - | - | - | - | <abbr title="Binary">b</abbr> | * | * | * | * | The values of the Tag if it is binary. Note that this cannot be used in the same SimpleTag as TagString. |
+| Element Name | <abbr title="Level">L</abbr> | EBML ID | <abbr title="Mandatory">Ma</abbr> | <abbr title="Multiple">Mu</abbr> | <abbr title="Range">Rng</abbr> | Default | <abbr title="Element Type">T</abbr> | <abbr title="Version 1">1</abbr> | <abbr title="Version 2">2</abbr> | <abbr title="Version 3">3</abbr> | <abbr title="Version 4">4</abbr> | <abbr title="WebM">W</abbr> | Description |
+
+
+
+**All top-levels elements (Segment and direct sub-elements) are coded on 4 octets, i.e. class D elements.**
+
+### Appendix
+
+#### Language Codes
+
+Language codes can be either the 3 letters [bibliographic ISO-639-2](http://www.loc.gov/standards/iso639-2/php/English_list.php) form (like "fre" for french), or such a language code followed by a dash and a country code for specialities in languages (like "fre-ca" for Canadian French). Country codes are the same as used for [internet domains](http://www.iana.org/cctld/cctld-whois.htm).
+
+#### Physical Types
+
+Each level can have different meanings for audio and video. The ORIGINAL_MEDIUM tag can be used to specify a string for ChapterPhysicalEquiv = 60\. Here is the list of possible levels for both audio and video :
+
+| ChapterPhysicalEquiv | Audio | Video | Comment |
+| 70 | SET / PACKAGE | SET / PACKAGE | the collection of different media |
+| 60 | CD / 12" / 10" / 7" / TAPE / MINIDISC / DAT | DVD / VHS / LASERDISC | the physical medium like a CD or a DVD |
+| 50 | SIDE | SIDE | when the original medium (LP/DVD) has different sides |
+| 40 | - | LAYER | another physical level on DVDs |
+| 30 | SESSION | SESSION | as found on CDs and DVDs |
+| 20 | TRACK | - | as found on audio CDs |
+| 10 | INDEX | - | the first logical level of the side/medium |
+
+
+#### Block Structure
+
+Size = 1 + (1-8) + 4 + (4 + (4)) octets. So from 6 to 21 octets.
+
+Bit 0 is the most significant bit.
+
+Frames using references should be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timecodes may not be consecutive. But a frame with a past timecode must reference a frame already known, otherwise it's considered bad/void.
+
+There can be many Blocks in a BlockGroup provided they all have the same timecode. It is used with different parts of a frame with different priorities.
+
+| Block Header |
+| Offset | Player | Description |
+| 0x00+ | must | Track Number (Track Entry). It is coded in EBML like form (1 octet if the value is < 0x80, 2 if < 0x4000, etc) (most significant bits set to increase the range). |
+| 0x01+ | must | Timecode (relative to Cluster timecode, signed int16) |
+| 0x03+ | - | 
+
+| Flags |
+| Bit | Player | Description |
+| 0-3 | - | Reserved, set to 0 |
+| 4 | - | Invisible, the codec should decode this frame but not display it |
+| 5-6 | must | Lacing
+
+*   00 : no lacing
+*   01 : Xiph lacing
+*   11 : EBML lacing
+*   10 : fixed-size lacing
+
+ |
+| 7 | - | not used |
+
+ |
+| Lace (when lacing bit is set) |
+| 0x00 | must | Number of frames in the lace-1 (uint8) |
+| 0x01 / 0xXX | must* | Lace-coded size of each frame of the lace, except for the last one (multiple uint8). *This is not used with Fixed-size lacing as it is calculated automatically from (total size of lace) / (number of frames in lace). |
+| (possibly) Laced Data |
+| 0x00 | must | Consecutive laced frames |
+
+
+### Lacing
+
+Lacing is a mechanism to save space when storing data. It is typically used for small blocks of data (refered to as frames in matroska). There are 3 types of lacing : the Xiph one inspired by what is found in the Ogg container, the EBML one which is the same with sizes coded differently and the fixed-size one where the size is not coded. As an example is better than words...
+
+Let's say you want to store 3 frames of the same track. The first frame is 800 octets long, the second is 500 octets long and the third is 1000 octets long. As these data are small, you can store them in a lace to save space. They will then be solved in the same block as follows:
+
+#### Xiph lacing
+
+*   Block head (with lacing bits set to 01)
+*   Lacing head: Number of frames in the lace -1, i.e. 2 (the 800 and 500 octets one)
+*   Lacing sizes: only the 2 first ones will be coded, 800 gives 255;255;255;35, 500 gives 255;245\. The size of the last frame is deduced from the total size of the Block.
+*   Data in frame 1
+*   Data in frame 2
+*   Data in frame 3
+
+A frame with a size multiple of 255 is coded with a 0 at the end of the size, for example 765 is coded 255;255;255;0.
+
+#### EBML lacing
+
+In this case the size is not coded as blocks of 255 bytes, but as a difference with the previous size and this size is coded as in EBML. The first size in the lace is unsigned as in EBML. The others use a range shifting to get a sign on each value :
+
+<pre>1xxx xxxx                                                                              - value -(2^6-1) to  2^6-1
+
+                                                                                        (ie 0 to 2^7-2 minus 2^6-1, half of the range)
+
+01xx xxxx  xxxx xxxx                                                                   - value -(2^13-1) to 2^13-1
+
+001x xxxx  xxxx xxxx  xxxx xxxx                                                        - value -(2^20-1) to 2^20-1
+
+0001 xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx                                             - value -(2^27-1) to 2^27-1
+
+0000 1xxx  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx                                  - value -(2^34-1) to 2^34-1
+
+0000 01xx  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx                       - value -(2^41-1) to 2^41-1
+
+0000 001x  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx  xxxx xxxx            - value -(2^48-1) to 2^48-1
+
+</pre>
+
+*   Block head (with lacing bits set to 11)
+*   Lacing head: Number of frames in the lace -1, i.e. 2 (the 800 and 400 octets one)
+*   Lacing sizes: only the 2 first ones will be coded, 800 gives 0x320 0x4000 = 0x4320, 500 is coded as -300 : - 0x12C + 0x1FFF + 0x4000 = 0x5ED3\. The size of the last frame is deduced from the total size of the Block.
+*   Data in frame 1
+*   Data in frame 2
+*   Data in frame 3
+
+#### Fixed-size lacing
+
+In this case only the number of frames in the lace is saved, the size of each frame is deduced from the total size of the Block. For example, for 3 frames of 800 octets each :
+
+*   Block head (with lacing bits set to 10)
+*   Lacing head: Number of frames in the lace -1, i.e. 2
+*   Data in frame 1
+*   Data in frame 2
+*   Data in frame 3
+
+
+#### SimpleBlock Structure
+
+The SimpleBlock is very inspired by the [Block structure](#block_structure). The main differences are the added Keyframe flag and Discardable flag. Otherwise everything is the same.
+
+Size = 1 + (1-8) + 4 + (4 + (4)) octets. So from 6 to 21 octets.
+
+Bit 0 is the most significant bit.
+
+Frames using references should be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timecodes may not be consecutive. But a frame with a past timecode must reference a frame already known, otherwise it's considered bad/void.
+
+There can be many Blocks in a BlockGroup provided they all have the same timecode. It is used with different parts of a frame with different priorities.
+
+
+
+| SimpleBlock Header |
+| Offset | Player | Description |
+| 0x00+ | must | Track Number (Track Entry). It is coded in EBML like form (1 octet if the value is < 0x80, 2 if < 0x4000, etc) (most significant bits set to increase the range). |
+| 0x01+ | must | Timecode (relative to Cluster timecode, signed int16) |
+| 0x03+ | - | 
+
+| Flags |
+| Bit | Player | Description |
+| 0 | - | Keyframe, set when the Block contains only keyframes |
+| 1-3 | - | Reserved, set to 0 |
+| 4 | - | Invisible, the codec should decode this frame but not display it |
+| 5-6 | must | Lacing
+
+*   00 : no lacing
+*   01 : Xiph lacing
+*   11 : EBML lacing
+*   10 : fixed-size lacing
+
+ |
+| 7 | - | Discardable, the frames of the Block can be discarded during playing if needed |
+
+ |
+| Lace (when lacing bit is set) |
+| 0x00 | must | Number of frames in the lace-1 (uint8) |
+| 0x01 / 0xXX | must* | Lace-coded size of each frame of the lace, except for the last one (multiple uint8). *This is not used with Fixed-size lacing as it is calculated automatically from (total size of lace) / (number of frames in lace). |
+| (possibly) Laced Data |
+| 0x00 | must | Consecutive laced frames |
+
+
+#### EncryptedBlock Structure
+
+The EncryptedBlock is very inspired by the [SimpleBlock structure](#simpleblock_structure). The main differences is that the raw data are Transformed. That means the data after the lacing definition (if present) have been processed before put into the Block. The laced sizes apply on the decoded (Inverse Transform) data. This size of the Transformed data may not match the size of the initial chunk of data.
+
+The other difference is that the number of frames in the lace are not saved if "no lacing" is specified (bits 5 and 6 set to 0).
+
+The Transformation is specified by a TransformID in the Block (must be the same for all frames within the EncryptedBlock).
+
+Size = 1 + (1-8) + 4 + (4 + (4)) octets. So from 6 to 21 octets.
+
+Bit 0 is the most significant bit.
+
+Frames using references should be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timecodes may not be consecutive. But a frame with a past timecode must reference a frame already known, otherwise it's considered bad/void.
+
+There can be many Blocks in a BlockGroup provided they all have the same timecode. It is used with different parts of a frame with different priorities.
+
+
+
+| EncryptedBlock Header |
+| Offset | Player | Description |
+| 0x00+ | must | Track Number (Track Entry). It is coded in EBML like form (1 octet if the value is < 0x80, 2 if < 0x4000, etc) (most significant bits set to increase the range). |
+| 0x01+ | must | Timecode (relative to Cluster timecode, signed int16) |
+| 0x03+ | - | 
+
+| Flags |
+| Bit | Player | Description |
+| 0 | - | Keyframe, set when the Block contains only keyframes |
+| 1-3 | - | Reserved, set to 0 |
+| 4 | - | Invisible, the codec should decode this frame but not display it |
+| 5-6 | must | Lacing
+
+*   00 : no lacing
+*   01 : Xiph lacing
+*   11 : EBML lacing
+*   10 : fixed-size lacing
+
+ |
+| 7 | - | Discardable, the frames of the Block can be discarded during playing if needed |
+
+ |
+| Lace (when lacing bit is set) |
+| 0x00 | must* | Number of frames in the lace-1 (uint8) *Only available if bit 5 or bit 6 of the EncryptedBlock flag is set to one. |
+| 0x01 / 0xXX | must* | Lace-coded size of each frame of the lace, except for the last one (multiple uint8). *This is not used with Fixed-size lacing as it is calculated automatically from (total size of lace) / (number of frames in lace). |
+| (possibly) Laced Data |
+| 0x00 | must | TransformID (EBML coded integer value). Value 0 = Null Transform |
+| 0x01+ | must | Consecutive laced frames |
+
+
+#### Virtual Block
+
+The data in matroska is stored in coding order. But that means if you seek to a particular point and a frame has been referenced far away, you won't know while playing and you might miss this frame (true for independent frames and overlapping of dependent frames). So the idea is to have a placeholder for the original frame in the timecode (display) order.
+
+The structure is a scaled down version of the normal [Block](#block).
+
+
+| Virtual Block Header |
+| Offset | Player | Description |
+| 0x00+ | must | Track Number (Track Entry). It is coded in EBML like form (1 octet if the value is < 0x80, 2 if < 0x4000, etc) (most significant bits set to increase the range). |
+| 0x01+ | must | Timecode (relative to Cluster timecode, signed int16) |
+| 0x03+ | - | 
+
+| Flags |
+| Bit | Player | Description |
+| 7-0 | - | Reserved, set to 0 |
+
+ |

--- a/tagging.md
+++ b/tagging.md
@@ -1,0 +1,673 @@
+---
+layout: default
+---
+
+# Elements semantic
+ 
+
++ Element Name - The full name of the described element.
++ L - Level - The level within an EBML tree that the element may occur at. + is for a recursive level (can be its own child). g: global element (can be found at any level)
++ EBML ID - The Element ID displayed as octets.
++ Ma - Mandatory - This element is mandatory in the file (abbreviated as »mand.«).
++ Mu - Multiple - The element may appear multiple times within its parent element (abbreviated as »mult.«).
++ Rng - Range - Valid range of values to store in the element.
++ Default - The default value of the element.
++ T - Element Type - The form of data the element contains. m: Master, u: unsigned int, i: signed integer, s: string, 8: UTF-8 string, b: binary, f:float, d: date
++ 1 - The element is contained in Matroska version 1.
++ 2 - The element is contained in Matroska version 2.
++ 3 - The element is contained in Matroska version 3.
++ 4 - The element is contained in Matroska version 4 (v4 is still work in progress; further additions are possible).
++ W - All elements available for use in WebM.
++ Description - A short description of the element's purpose.
+
+
+
+
+<table><tbody><tr class="toptitle"><th style="white-space: nowrap">Element Name</th>
+      <th title="Level"><abbr title="Level">L</abbr> </th>
+      <th style="white-space: nowrap">EBML ID</th>
+      <th title="Mandatory"><abbr title="Mandatory">Ma</abbr> </th>
+      <th title="Multiple"><abbr title="Multiple">Mu</abbr> </th>
+      <th title="Range"><abbr title="Range">Rng</abbr> </th>
+      <th>Default</th>
+      <th title="Element Type"><abbr title="Element Type">T</abbr> </th>
+      <th title="Version 1"><abbr title="Version 1">1</abbr> </th>
+      <th title="Version 2"><abbr title="Version 2">2</abbr> </th>
+      <th title="Version 3"><abbr title="Version 3">3</abbr> </th>
+      <th title="Version 4"><abbr title="Version 4">4</abbr> </th>
+      <th title="WebM"><abbr title="WebM">W</abbr> </th>
+      <th>Description</th>
+    </tr><tr><th colspan="14" id="Tagging">Tagging</th>
+    </tr><tr id="Tags" class="level1"><td>Tags</td>
+      <td>1</td>
+      <td>[12][54][C3][67]</td>
+      <td class="unset">-</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="Master Elements">m</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Element containing elements specific to Tracks/Chapters. A list of valid tags can be found <a href="http://www.matroska.org/technical/specs/tagging/index.html">here.</a></td>
+    </tr><tr id="Tag" class="level2"><td>Tag</td>
+      <td>2</td>
+      <td>[73][73]</td>
+      <td>mand.</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="Master Elements">m</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Element containing elements specific to Tracks/Chapters.</td>
+    </tr><tr id="Targets" class="level3"><td>Targets</td>
+      <td>3</td>
+      <td>[63][C0]</td>
+      <td>mand.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="Master Elements">m</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Contain all UIDs where the specified meta data apply. It is empty to describe everything in the segment.</td>
+    </tr><tr id="TargetTypeValue" class="level4"><td>TargetTypeValue</td>
+      <td>4</td>
+      <td>[68][CA]</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td>50</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>A number to indicate the logical level of the target (see <a href="http://www.matroska.org/technical/specs/tagging/index.html#targettypes">TargetType</a>).</td>
+    </tr><tr id="TargetType" class="level4"><td>TargetType</td>
+      <td>4</td>
+      <td>[63][CA]</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="String">s</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>An <strong>informational</strong> string that can be used to display the logical level of the target like "ALBUM", "TRACK", "MOVIE", "CHAPTER", etc (see <a href="http://www.matroska.org/technical/specs/tagging/index.html#targettypes">TargetType</a>).</td>
+    </tr><tr id="TagTrackUID" class="level4"><td>TagTrackUID</td>
+      <td>4</td>
+      <td>[63][C5]</td>
+      <td class="unset">-</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td>0</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>A unique ID to identify the Track(s) the tags belong to. If the value is 0 at this level, the tags apply to all tracks in the Segment.</td>
+    </tr><tr id="TagEditionUID" class="level4"><td>TagEditionUID</td>
+      <td>4</td>
+      <td>[63][C9]</td>
+      <td class="unset">-</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td>0</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>A unique ID to identify the EditionEntry(s) the tags belong to. If the value is 0 at this level, the tags apply to all editions in the Segment.</td>
+    </tr><tr id="TagChapterUID" class="level4"><td>TagChapterUID</td>
+      <td>4</td>
+      <td>[63][C4]</td>
+      <td class="unset">-</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td>0</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>A unique ID to identify the Chapter(s) the tags belong to. If the value is 0 at this level, the tags apply to all chapters in the Segment.</td>
+    </tr><tr id="TagAttachmentUID" class="level4"><td>TagAttachmentUID</td>
+      <td>4</td>
+      <td>[63][C6]</td>
+      <td class="unset">-</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td>0</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>A unique ID to identify the Attachment(s) the tags belong to. If the value is 0 at this level, the tags apply to all the attachments in the Segment.</td>
+    </tr><tr id="SimpleTag" class="level3"><td>SimpleTag</td>
+      <td>3+</td>
+      <td>[67][C8]</td>
+      <td>mand.</td>
+      <td>mult.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="Master Elements">m</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Contains general information about the target.</td>
+    </tr><tr id="TagName" class="level4"><td>TagName</td>
+      <td>4</td>
+      <td>[45][A3]</td>
+      <td>mand.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="UTF-8">8</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>The name of the Tag that is going to be stored.</td>
+    </tr><tr id="TagLanguage" class="level4"><td>TagLanguage</td>
+      <td>4</td>
+      <td>[44][7A]</td>
+      <td>mand.</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td>und</td>
+      <td><abbr title="String">s</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Specifies the language of the tag specified, in the <a href="http://www.matroska.org/technical/specs/index.html#languages">Matroska languages form</a>.</td>
+    </tr><tr id="TagDefault" class="level4"><td>TagDefault</td>
+      <td>4</td>
+      <td>[44][84]</td>
+      <td>mand.</td>
+      <td class="unset">-</td>
+      <td>0-1</td>
+      <td>1</td>
+      <td><abbr title="Unsigned Integer">u</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>Indication to know if this is the default/original language to use for the given tag. (1 bit)</td>
+    </tr><tr id="TagString" class="level4"><td>TagString</td>
+      <td>4</td>
+      <td>[44][87]</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="UTF-8">8</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>The value of the Tag.</td>
+    </tr><tr id="TagBinary" class="level4"><td>TagBinary</td>
+      <td>4</td>
+      <td>[44][85]</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td class="unset">-</td>
+      <td><abbr title="Binary">b</abbr> </td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td>*</td>
+      <td class="flagnot"></td>
+      <td>The values of the Tag if it is binary. Note that this cannot be used in the same SimpleTag as TagString.</td>
+    </tr></tbody></table>
+
+When a Tag is nested within another Tag, the nested Tag becomes an attribute
+  of the base tag. For instance, if you wanted to store the dates that a singer
+  used certain addresses for, that singer being the lead singer for a track that
+  included multiple bands simultaneously, then your tag tree would look something
+  like this:
+ Targets<br />
+  - TrackUID<br />
+  BAND<br />
+  - LEADPERFORMER<br />
+  -- ADDRESS<br />
+  --- DATE<br />
+  --- DATEEND<br />
+  -- ADDRESS<br />
+  --- DATE
+In this way, it becomes possible to store any Tag as attributes of another
+  tag.
+Multiple items should never be stored as a list in a single TagString. If there
+  is more than one tag of a certain type to be stored, then more than one SimpleTag
+  should be used. 
+For authoring Tags outside of EBML, the <a href="http://www.matroska.org/files/tags/matroskatags.dtd">following XML syntax is proposed</a> (<a href="http://www.bunkus.org/videotools/mkvtoolnix/doc/mkvmerge.html#mkvmerge.tags">used in mkvmerge</a>). Binary
+  data should be stored using BASE64 encoding if it is being stored at authoring
+  time.
+
+## Why official tags matter
+
+There is a debate between people who think all tags should be free and those who think all tags should be strict. If you look at this page you will realise we are in between.
+
+Advanced-users application might let you put any tag in your file. But for the rest of the applications, they usually give you a basic list of tags you can use. Both have their needs. But it's usually a bad idea to use custom/exotic tags because <em>you</em> will probably be the only person to use this information even though everyone else could benefit from it. So hopefully when someone wants to put information in one's file, they will find an official one that fit them and hopefully use it ! If it's not in the list, this person can contact us any time for addition of such a missing tag. But it doesn't mean it will be accepted... Matroska files are not meant the become a whole database of people who made costumes for a film. A website would be better for that... It's hard to define what should be in and what doesn't make sense in a file. So we'll treat each request carefully.
+
+We also need an official list simply for developpers to be able to display relevant information in their own design (if they choose to support a list of meta-information they should know which tag has the wanted meaning so that other apps could understand the same meaning).
+
+## Tag translations
+To be able to save tags from other systems to Matroska we need to translate them to our system. There is a translation table <a href="othertagsystems/comparetable.html">on our site</a>.
+
+## Tag Formatting
+
+* The TagName should always be written in all capital letters and contain no space.
+* The fields with dates should have the following format: YYYY-MM-DD
+    HH:MM:SS.MSS YYYY = Year, -MM = Month, -DD = Days, HH = Hours, :MM = Minutes,
+    :SS = Seconds, :MSS = Milliseconds. To store less accuracy, you remove items
+    starting from the right. To store only the year, you would use, "2004".
+    To store a specific day such as May 1st, 2003, you would use "2003-05-01".
+  
+* Fields that require a Float should use the "."
+    mark instead of the "," mark. To display it differently for another
+    local, applications should support auto replacement on display. Also, a thousandths
+    separator should not be used.
+* For currency amounts, there should only be a numeric value in the Tag. Only
+    numbers, no letters or symbols other than ".". For instance, you
+    would store "15.59" instead of "$15.59USD".
+
+## Target types
+
+The TargetType element allows tagging of different parts that are inside or outside a given file. For example in an audio file with one song you could have information about the album it comes from and even the CD set even if it's not found in the file.
+
+For application to know what kind of information (like TITLE) relates to a certain level (CD title or track title), we also need a set of official TargetType names. For now audio and video will have different values &amp; names. That also means the same tag name can have different meanings depending on where it is (otherwise we would end up with 15 TITLE_ tags).
+
+
+<table style="width: 100%;"><tr><th>TargetTypeValue</th><th>Audio strings</th><th>Video strings</th><th>Comment</th></tr><tr><td>70</td><td>COLLECTION</td><td>COLLECTION</td><td>the high hierarchy consisting of many different lower items</td></tr><tr><td>60</td><td>EDITION / ISSUE / VOLUME / OPUS</td><td>SEASON / SEQUEL / VOLUME</td><td>a list of lower levels grouped together</td></tr><tr><td>50</td><td>ALBUM / OPERA / CONCERT</td><td>MOVIE / EPISODE / CONCERT</td><td>the most common grouping level of music and video (equals to an episode for TV series)</td></tr><tr><td>40</td><td>PART / SESSION</td><td>PART / SESSION</td><td>when an album or episode has different logical parts</td></tr><tr><td>30</td><td>TRACK / SONG</td><td>CHAPTER</td><td>the common parts of an album or a movie</td></tr><tr><td>20</td><td>SUBTRACK / PART / MOVEMENT</td><td>SCENE</td><td>corresponds to parts of a track for audio (like a movement)</td></tr><tr><td>10</td><td>-</td><td>SHOT</td><td>the lowest hierarchy found in music or movies</td></tr></table>
+
+An upper level value tag applies to the lower level. That means if a CD has the same artist for all tracks, you just need to set the ARTIST tag at level 40 (ALBUM) and not to each TRACK (but you can). That also means that <strong>if some parts of the CD have no known ARTIST the value must be set to nothing (a void string "")</strong>.
+
+<strong>When a level doesn't exist it must not be specified in the files, so that the TOTAL_PARTS and PART_NUMBER elements match the same levels.</strong>
+
+Here is an example of how these <a href="#Organizational">organizational</a> tags work: If you set 10 TOTAL_PARTS to the ALBUM level (40) it means the album contains 10 lower parts. The lower part in question is the first lower level that is specified in the file. So if it's TRACK (30) then that means it contains 10 tracks. If it's MOVEMENT (20) that means it's 10 movements, etc.
+
+## Official tags 
+
+The following is a complete list of the supported Matroska
+  Tags. While it is possible to use Tag names that are not listed below, this
+  is not reccommended as compatability will be compromised. If you find that there
+  is a Tag missing that you would like to use, then please contact the Matroska
+  team for its inclusion in the specifications before the format reaches 1.0.
+
+
+
+<table><tr><th colspan="5" id="nesting">Nesting Information (tags containing other tags)</th>
+  </tr><tr><td>ORIGINAL</td>
+    <td>-</td>
+    <td>A special tag that is meant to have other tags inside (using nested tags) to describe the original work of art that this item is based on. All tags in this list can be used "under" the ORIGINAL tag like LYRICIST, PERFORMER, etc.</td>
+  </tr><tr><td>SAMPLE</td>
+    <td>-</td>
+    <td>A tag that contains other tags to describe a sample used in the targeted item taken from another work of art. All tags in this list can be used "under" the SAMPLE tag like TITLE, ARTIST, DATE_RELEASED, etc.</td>
+  </tr><tr id="country"><td>COUNTRY</td>
+    <td>UTF-8</td>
+    <td>The name of the country (<a href="http://lcweb.loc.gov/standards/iso639-2/englangn.html#two">biblio ISO-639-2</a>) that is meant to have other tags inside (using nested tags) to country specific information about the item. All tags in this list can be used "under" the COUNTRY_SPECIFIC tag like LABEL, PUBLISH_RATING, etc.</td>
+  </tr><tr><th colspan="3" style="color: #f00;">Colour coding</th></tr><tr class="subjective" style="text-align: center"><td colspan="3">subjective information</td></tr><tr class="version2" style="text-align: center"><td colspan="3">subject to change or removal</td></tr><tr><th title="Used as TagName">Tag Name</th>
+    <th title="Defines if either TagString or TagBinary is used" style="white-space: nowrap">Type</th>
+    <th>Description</th>
+  </tr><tr id="Organizational"><th colspan="5">Organizational Information</th>
+  </tr><tr><td>TOTAL_PARTS</td>
+    <td style="white-space: nowrap">UTF-8</td>
+    <td>Total number of parts defined at the first lower level. (e.g. if TargetType is ALBUM, the total number of tracks of an audio CD)</td>
+  </tr><tr><td>PART_NUMBER</td>
+    <td>UTF-8</td>
+    <td>Number of the current part of the current level. (e.g. if TargetType is TRACK, the track number of an audio CD)</td>
+  </tr><tr><td>PART_OFFSET</td>
+    <td>UTF-8</td>
+    <td>A number to add to PART_NUMBER when the parts at that level don't start at 1. (e.g. if TargetType is TRACK, the track number of the second audio CD)</td>
+  </tr><tr id="titles"><th colspan="5">Titles</th>
+  </tr><tr><td>TITLE</td>
+    <td>UTF-8</td>
+    <td>The title of this item. For example, for music you might
+      label this "Canon in D", or for video's audio track you might use "English
+      5.1" This is akin to the TIT2 tag in ID3.</td>
+  </tr><tr><td>SUBTITLE</td>
+    <td>UTF-8</td>
+    <td>Sub Title of the entity.</td>
+  </tr><tr id="nested"><th colspan="5">Nested Information (tags contained in other tags)</th>
+  </tr><tr id="URL"><td>URL</td>
+    <td>UTF-8</td>
+    <td>URL corresponding to the tag it's included in.</td>
+  </tr><tr><td>SORT_WITH</td>
+    <td>UTF-8</td>
+    <td>A child element to indicate what alternative value the parent tag can have to be sorted, for example "Pet Shop Boys" instead of "The Pet Shop Boys". Or "Marley Bob" and "Marley Ziggy" (no comma needed).</td>
+  </tr><tr><td>INSTRUMENTS</td>
+    <td>UTF-8</td>
+    <td>The instruments that are being used/played, separated by a comma. It should be a child of the following tags: ARTIST, LEAD_PERFORMER or ACCOMPANIMENT.</td>
+  </tr><tr id="Email"><td>EMAIL</td>
+    <td>UTF-8</td>
+    <td>Email corresponding to the tag it's included in.</td>
+  </tr><tr id="Address"><td>ADDRESS</td>
+    <td>UTF-8</td>
+    <td>The physical address of the entity. The address should include a country code. It can be useful for a recording label.</td>
+  </tr><tr id="Fax"><td>FAX</td>
+    <td>UTF-8</td>
+    <td>The fax number corresponding to the tag it's included in. It can be useful for a recording label.</td>
+  </tr><tr id="Phone"><td>PHONE</td>
+    <td>UTF-8</td>
+    <td>The phone number corresponding to the tag it's included in. It can be useful for a recording label.</td>
+  </tr><tr id="Entities"><th colspan="5">Entities</th>
+  </tr><tr><td>ARTIST</td>
+    <td>UTF-8</td>
+    <td>A person or band/collective generally considered responsible for the work. This is akin to the <a href="http://id3.org/id3v2.3.0#TPE1">TPE1 tag in ID3.</a></td>
+  </tr><tr><td>LEAD_PERFORMER</td>
+    <td>UTF-8</td>
+    <td>Lead Performer/Soloist(s). This can sometimes be the same as ARTIST.</td>
+  </tr><tr><td>ACCOMPANIMENT</td>
+    <td>UTF-8</td>
+    <td>Band/orchestra/accompaniment/musician. This is akin to the <a href="http://id3.org/id3v2.3.0#TPE2">TPE2 tag in ID3.</a></td>
+  </tr><tr><td>COMPOSER</td>
+    <td>UTF-8</td>
+    <td>The name of the composer of this item. This is akin to the <a href="http://id3.org/id3v2.3.0#TCOM">TCOM
+      tag in ID3.</a></td>
+  </tr><tr><td>ARRANGER</td>
+    <td>UTF-8</td>
+    <td>The person who arranged the piece, e.g., Ravel.</td>
+  </tr><tr><td>LYRICS</td>
+    <td>UTF-8</td>
+    <td>The lyrics corresponding to a song (in case audio synchronization is not known or as a doublon to a subtitle track). Editing this value when subtitles are found should also result in editing the subtitle track for more consistency.</td>
+  </tr><tr><td>LYRICIST</td>
+    <td>UTF-8</td>
+    <td>The person who wrote the lyrics for a musical item. This is akin to
+      the <a href="http://id3.org/id3v2.3.0#TEXT">TEXT</a>
+      tag in ID3.</td>
+  </tr><tr><td>CONDUCTOR</td>
+    <td>UTF-8</td>
+    <td>Conductor/performer refinement. This is akin to the <a href="http://id3.org/id3v2.3.0#TPE3">TPE3
+      tag in ID3.</a></td>
+  </tr><tr><td>DIRECTOR</td>
+    <td>UTF-8</td>
+    <td>This is akin to the <a href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/RIFF.html">IART
+      tag in RIFF</a>.</td>
+  </tr><tr><td>ASSISTANT_DIRECTOR</td>
+    <td>UTF-8</td>
+    <td>The name of the assistant director.</td>
+  </tr><tr><td>DIRECTOR_OF_PHOTOGRAPHY</td>
+    <td>UTF-8</td>
+    <td>The name of the director of photography, also known as cinematographer. This is akin to the ICNM tag in Extended RIFF.</td>
+  </tr><tr><td>SOUND_ENGINEER</td>
+    <td>UTF-8</td>
+    <td>The name of the sound engineer or sound recordist.</td>
+  </tr><tr><td>ART_DIRECTOR</td>
+    <td>UTF-8</td>
+    <td>The person who oversees the artists and craftspeople who build the sets.</td>
+  </tr><tr><td>PRODUCTION_DESIGNER</td>
+    <td>UTF-8</td>
+    <td>Artist responsible for designing the overall visual appearance of a movie.</td>
+  </tr><tr><td>CHOREGRAPHER</td>
+    <td>UTF-8</td>
+    <td>The name of the choregrapher</td>
+  </tr><tr><td>COSTUME_DESIGNER</td>
+    <td>UTF-8</td>
+    <td>The name of the costume designer</td>
+  </tr><tr><td>ACTOR</td>
+    <td>UTF-8</td>
+    <td>An actor or actress playing a role in this movie. This is the person's
+    real name, not the character's name the person is playing.</td>
+  </tr><tr><td>CHARACTER</td>
+    <td>UTF-8</td>
+    <td>The name of the character an actor or actress plays in this
+    movie. This should be a sub-tag of an <code>ACTOR</code> tag in order not
+    to cause ambiguities.</td>
+  </tr><tr><td>WRITTEN_BY</td>
+    <td>UTF-8</td>
+    <td>The author of the story or script (used for movies and TV shows).</td>
+  </tr><tr><td>SCREENPLAY_BY</td>
+    <td>UTF-8</td>
+    <td>The author of the screenplay or scenario (used for movies and TV shows).</td>
+  </tr><tr><td>EDITED_BY</td>
+    <td>UTF-8</td>
+    <td>This is akin to the IEDT tag in Extended RIFF.</td>
+  </tr><tr><td>PRODUCER</td>
+    <td>UTF-8</td>
+    <td>Produced by. This is akin to the IPRO tag in Extended RIFF.</td>
+  </tr><tr><td>COPRODUCER</td>
+    <td>UTF-8</td>
+    <td>The name of a co-producer.</td>
+  </tr><tr><td>EXECUTIVE_PRODUCER</td>
+    <td>UTF-8</td>
+    <td>The name of an executive producer.</td>
+  </tr><tr><td>DISTRIBUTED_BY</td>
+    <td>UTF-8</td>
+    <td>This is akin to the IDST tag in Extended RIFF.</td>
+  </tr><tr><td>MASTERED_BY</td>
+    <td>UTF-8</td>
+    <td>The engineer who mastered the content for a physical medium or for digital distribution.</td>
+  </tr><tr><td>ENCODED_BY</td>
+    <td>UTF-8</td>
+    <td>This is akin to the <a href="http://id3.org/id3v2.3.0#TENC">TENC tag</a> in ID3.</td>
+  </tr><tr><td>MIXED_BY</td>
+    <td>UTF-8</td>
+    <td>DJ mix by the artist specified</td>
+  </tr><tr><td>REMIXED_BY</td>
+    <td>UTF-8</td>
+    <td>Interpreted, remixed, or otherwise modified by. This is akin to the <a href="http://id3.org/id3v2.3.0#TPE4">TPE4
+      tag in ID3.</a></td>
+  </tr><tr><td>PRODUCTION_STUDIO</td>
+    <td>UTF-8</td>
+    <td>This is akin to the ISTD tag in Extended RIFF.</td>
+  </tr><tr><td>THANKS_TO</td>
+    <td>UTF-8</td>
+    <td>A very general tag for everyone else that wants to be listed.</td>
+  </tr><tr><td>PUBLISHER</td>
+    <td>UTF-8</td>
+    <td>This is akin to the <a href="http://id3.org/id3v2.3.0#TPUB">TPUB
+      tag in ID3.</a></td>
+  </tr><tr><td>LABEL</td>
+    <td>UTF-8</td>
+    <td>The record label or imprint on the disc.</td>
+  </tr><tr id="Search"><th colspan="5">Search / Classification</th>
+  </tr><tr class="subjective" id="Genre"><td>GENRE</td>
+    <td>UTF-8</td>
+    <td>The main genre (classical, ambient-house, synthpop, sci-fi, drama, etc). The format follows the infamous TCON tag in ID3.</td>
+  </tr><tr class="subjective" id="Mood"><td>MOOD</td>
+    <td>UTF-8</td>
+    <td>Intended to reflect the mood of the item with a few keywords, e.g. "Romantic", "Sad" or "Uplifting". The format follows that of the TMOO tag in ID3.</td>
+  </tr><tr id="OriginalMediaType"><td>ORIGINAL_MEDIA_TYPE</td>
+    <td>UTF-8</td>
+    <td>Describes the original type of the media, such as, "DVD",
+      "CD", "computer image," "drawing," "lithograph," and so forth. This is akin to
+      the <a href="http://id3.org/id3v2.3.0#TMED">TMED tag in ID3.</a></td>
+  </tr><tr id="Type"><td>CONTENT_TYPE</td>
+    <td>UTF-8</td>
+    <td>The type of the item. e.g. Documentary, Feature Film, Cartoon, Music Video, Music, Sound FX, ...</td>
+  </tr><tr id="Subject"><td>SUBJECT</td>
+    <td>UTF-8</td>
+    <td>Describes the topic of the file, such as "Aerial view of Seattle."</td>
+  </tr><tr id="Description"><td>DESCRIPTION</td>
+    <td>UTF-8</td>
+    <td>A short description of the content, such as "Two birds flying."</td>
+  </tr><tr id="Keywords"><td>KEYWORDS</td>
+    <td>UTF-8</td>
+    <td>Keywords to the item separated by a comma, used for searching.</td>
+  </tr><tr><td>SUMMARY</td>
+    <td>UTF-8</td>
+    <td>A plot outline or a summary of the story.</td>
+  </tr><tr><td>SYNOPSIS</td>
+    <td>UTF-8</td>
+    <td>A description of the story line of the item. </td>
+  </tr><tr id="InitialKey"><td>INITIAL_KEY</td>
+    <td>UTF-8</td>
+    <td>The initial key that a musical track starts in. The format is identical
+      to ID3.</td>
+  </tr><tr><td>PERIOD</td>
+    <td>UTF-8</td>
+    <td>Describes the period that the piece is from or about. For example, "Renaissance". </td>
+  </tr><tr id="law_rating"><td>LAW_RATING</td>
+    <td>UTF-8</td>
+    <td>Depending on the <a href="#country">country</a> it's the format of the rating of a movie (P, R, X in the USA, an age in other countries or a URI defining a logo).</td>
+  </tr><tr id="icra"><td>ICRA</td>
+    <td>binary</td>
+    <td>The <a href="http://www.icra.org/">ICRA</a> content rating for parental control. (Previously RSACi)</td>
+  </tr><tr id="Temporal"><th colspan="5">Temporal Information</th>
+  </tr><tr><td>DATE_RELEASED</td>
+    <td>UTF-8</td>
+    <td>The time that the item was originaly released. This is akin to the TDRL
+      tag in ID3.</td>
+  </tr><tr><td>DATE_RECORDED</td>
+    <td>UTF-8</td>
+    <td>The time that the recording began. This is akin to the TDRC
+      tag in ID3.</td>
+  </tr><tr><td>DATE_ENCODED</td>
+    <td>UTF-8</td>
+    <td>The time that the encoding of this item was completed began. This is akin to the TDEN tag in ID3.</td>
+  </tr><tr><td>DATE_TAGGED</td>
+    <td>UTF-8</td>
+    <td>The time that the tags were done for this item. This is akin to the TDTG tag in ID3.</td>
+  </tr><tr><td>DATE_DIGITIZED</td>
+    <td>UTF-8</td>
+    <td>The time that the item was tranfered to a digital medium. This is akin to the IDIT tag in RIFF.</td>
+  </tr><tr><td>DATE_WRITTEN</td>
+    <td>UTF-8</td>
+    <td>The time that the writing of the music/script began. </td>
+  </tr><tr><td>DATE_PURCHASED</td>
+    <td>UTF-8</td>
+    <td>Information on when the file was purchased (see also <a href="#commercial">purchase tags</a>).</td>
+  </tr><tr id="Spacial"><th colspan="5">Spacial Information</th>
+  </tr><tr><td>RECORDING_LOCATION</td>
+    <td>UTF-8</td>
+    <td>The location where the item was recorded. The countries corresponding to the string, same 2 octets as in <a href="http://www.iana.org/cctld/cctld-whois.htm">Internet domains</a>, or possibly <a href="http://www.iso.org/iso/country_codes">ISO-3166</a>. This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province. More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown, but you want to store the city, simply leave a space between the two commas. For example, "US, , Austin". </td>
+  </tr><tr><td>COMPOSITION_LOCATION</td>
+    <td>UTF-8</td>
+    <td>Location that the item was originaly designed/written. The countries corresponding to the string, same 2 octets as in <a href="http://www.iana.org/cctld/cctld-whois.htm">Internet domains</a>, or possibly <a href="http://www.iso.org/iso/country_codes">ISO-3166</a>. This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province. More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown, but you want to store the city, simply leave a space between the two commas. For example, "US, , Austin".</td>
+  </tr><tr><td>COMPOSER_NATIONALITY</td>
+    <td>UTF-8</td>
+    <td>Nationality of the main composer of the item, mostly for classical music. The countries corresponding to the string, same 2 octets as in <a href="http://www.iana.org/cctld/cctld-whois.htm">Internet domains</a>, or possibly <a href="http://www.iso.org/iso/country_codes">ISO-3166</a>.</td>
+  </tr><tr id="Personal"><th colspan="5">Personal</th>
+  </tr><tr class="subjective"><td>COMMENT</td>
+    <td>UTF-8</td>
+    <td>Any comment related to the content.</td>
+  </tr><tr class="subjective" id="PlayCounter"><td>PLAY_COUNTER</td>
+    <td>UTF-8</td>
+    <td>The number of time the item has been played.</td>
+  </tr><tr class="subjective" id="rating"><td>RATING</td>
+    <td>UTF-8</td>
+    <td>A numeric value defining how much a person likes the song/movie. The number is between 0 and 5 with decimal values possible (e.g. 2.7), 5(.0) being the highest possible rating. Other rating systems with different ranges will have to be scaled.</td>
+  </tr><tr id="Technical"><th colspan="5">Technical Information</th>
+  </tr><tr id="Encoder"><td>ENCODER</td>
+    <td>UTF-8</td>
+    <td>The software or hardware used to encode this item. ("LAME" or "XviD")</td>
+  </tr><tr id="EncodeSettings"><td>ENCODER_SETTINGS</td>
+    <td>UTF-8</td>
+    <td>A list of the settings used for encoding this item. No specific format.</td>
+  </tr><tr id="BitsPS"><td>BPS</td>
+    <td>UTF-8</td>
+    <td>The average bits per second of the specified item. This is only the data
+      in the Blocks, and excludes headers and any container overhead.</td>
+  </tr><tr id="FramesPS"><td>FPS</td>
+    <td>UTF-8</td>
+    <td>The average frames per second of the specified item. This is typically
+      the average number of Blocks per second. In the event that lacing is used,
+      each laced chunk is to be counted as a seperate frame. </td>
+  </tr><tr id="BPM"><td>BPM</td>
+    <td>UTF-8</td>
+    <td>Average number of beats per minute in the complete target (e.g. a chapter). Usually a decimal number.</td>
+  </tr><tr id="MEASURE"><td>MEASURE</td>
+    <td>UTF-8</td>
+    <td>In music, a measure is a unit of time in Western music like "4/4". It represents a regular grouping of beats, a meter, as indicated in musical notation by the time signature.. The majority of the contemporary rock and pop music you hear on the radio these days is written in the 4/4 time signature.</td>
+  </tr><tr id="TUNING"><td>TUNING</td>
+    <td>UTF-8</td>
+    <td>It is saved as a frequency in hertz to allow near-perfect tuning of instruments to the same tone as the musical piece (e.g. "441.34" in Hertz). The default value is 440.0 Hz.</td>
+  </tr><tr id="REPLAYGAIN_GAIN"><td>REPLAYGAIN_GAIN</td>
+    <td>binary</td>
+    <td>The gain to apply to reach 89dB SPL on playback. This is based on the <a href="http://www.replaygain.org/">Replay Gain standard</a>. Note that ReplayGain information can be found at all TargetType levels (track, album, etc).</td>
+  </tr><tr id="REPLAYGAIN_PEAK"><td>REPLAYGAIN_PEAK</td>
+    <td>binary</td>
+    <td>The maximum absolute peak value of the item. This is based on the <a href="http://www.replaygain.org/">Replay Gain standard</a>.</td>
+  </tr><tr id="identifiers"><th colspan="5">Identifiers</th>
+  </tr><tr><td>ISRC</td>
+    <td>UTF-8</td>
+    <td>The <a href="http://www.ifpi.org/isrc/isrc_handbook.html#Heading198">International Standard Recording Code</a>, excluding the "ISRC" prefix and including hyphens.</td>
+  </tr><tr><td>MCDI</td>
+    <td>binary</td>
+    <td>This is a binary dump of the TOC of the CDROM that this item was taken from. This holds the same information as the MCDI in ID3.</td>
+  </tr><tr><td>ISBN</td>
+    <td>UTF-8</td>
+    <td><a href="http://www.isbn-international.org/">International Standard Book Number</a></td>
+  </tr><tr><td>BARCODE</td>
+    <td>UTF-8</td>
+    <td><a href="http://www.ean-int.org/">EAN-13</a> (European Article Numbering) or <a href="http://www.uc-council.org/">UPC-A</a> (Universal Product Code) bar code identifier </td>
+  </tr><tr><td>CATALOG_NUMBER</td>
+    <td>UTF-8</td>
+    <td>A label-specific string used to identify the release (TIC 01 for example).</td>
+  </tr><tr><td>LABEL_CODE</td>
+    <td>UTF-8</td>
+    <td>A 4-digit or 5-digit number to identify the record label, typically printed as (LC) xxxx or (LC) 0xxxx on CDs medias or covers (only the number is stored).</td>
+  </tr><tr><td>LCCN</td>
+    <td>UTF-8</td>
+    <td><a href="http://www.loc.gov/marc/lccn.html">Library of Congress Control Number</a></td>
+  </tr><tr id="commercial"><th colspan="5">Commercial</th>
+  </tr><tr><td>PURCHASE_ITEM</td>
+    <td>UTF-8</td>
+    <td>URL to purchase this file. This is akin to the WPAY tag
+      in ID3.</td>
+  </tr><tr><td>PURCHASE_INFO</td>
+    <td>UTF-8</td>
+    <td>Information on where to purchase this album. This is akin to the WCOM
+      tag in ID3.</td>
+  </tr><tr><td>PURCHASE_OWNER</td>
+    <td>UTF-8</td>
+    <td>Information on the person who purchased the file. This is akin
+      to the <a href="http://id3.org/id3v2.3.0#TOWN">TOWN tag in ID3</a>.</td>
+  </tr><tr id="Price"><td>PURCHASE_PRICE</td>
+    <td>UTF-8</td>
+    <td>The amount paid for entity. There should only be a numeric value in here.
+      Only numbers, no letters or symbols other than ".". For instance,
+      you would store "15.59" instead of "$15.59USD".</td>
+  </tr><tr id="Currency"><td>PURCHASE_CURRENCY</td>
+    <td>UTF-8</td>
+    <td>The currency type used to pay for the entity. Use <a href="http://www.xe.com/iso4217.htm">ISO-4217</a> for the 3 letter currency code.</td>
+  </tr><tr id="legal"><th colspan="5">Legal</th>
+  </tr><tr><td>COPYRIGHT</td>
+    <td>UTF-8</td>
+    <td>The copyright information as per the copyright holder. This is akin to
+      the TCOP tag in ID3.</td>
+  </tr><tr><td>PRODUCTION_COPYRIGHT</td>
+    <td>UTF-8</td>
+    <td>The copyright information as per the production copyright holder. This
+      is akin to the TPRO tag in ID3.</td>
+  </tr><tr><td>LICENSE</td>
+    <td>UTF-8</td>
+    <td>The license applied to the content (like Creative Commons variants).</td>
+  </tr><tr><td>TERMS_OF_USE</td>
+    <td>UTF-8</td>
+    <td>The terms of use for this item. This is akin to the USER tag in ID3.</td>
+  </tr></table>
+
+# Notes
+
+* In the Target list, a logicial OR is applied on all tracks, a logicial OR is applied on all chapters. Then a logical AND is applied between the Tracks list and the Chapters list to know if an element belongs to this Target.


### PR DESCRIPTION
This PR converts a few more pages from the Matroska website into Markdown for eventual migration to Github Pages and updates some previously broken links in the specification pages. This also renames the specification page from index.md to specification.md for more clarity.

Added pages are Diagram, Specification Notes, and Tagging. Some more adjustments will need to be done but this gets it started.