### PR TITLE
Converts the other pages on Matroska.org

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,32 @@
+---
+layout: default
+---
+
+# License
+
+Matroska has several components that are licensed in different ways to maximize it's software and hardware adoption.
+
+| Component
+ | Description
+ | License
+ |
+| [LibEBML](http://dl.matroska.org/downloads/libebml/) | A simplified binary extension of XML for the purpose of storing and manipulating data in a hierarchical form with variable field lengths. | LGPL
+ |
+| [LibEBML2](https://matroska.svn.sourceforge.net/svnroot/matroska/trunk/foundation_src/libebml2/) | Another EBML parser with a similar interface to libEBML but written in C and under the BSD license. | BSD
+ |
+| [LibMatroska](http://dl.matroska.org/downloads/libmatroska/) | A C++ libary to parse Matroska files, it requires libEBML or libEBML2. | LGPL
+ |
+| [Core C](https://github.com/Matroska-Org/foundation-source/tree/master/corec) | A low level API layer for the C programming language. | BSD
+ |
+
+<big><span style="font-weight: bold;">Cost</span></big>
+There is no cost to use the components as long as you respect the license it is released under.
+<big>
+<span style="font-weight: bold;">Commercial Products</span></big>
+To help Matroska evolve we do encourage companies that release commercial hardware or software products that use Matroska or EBML to become a sponsor. In exchange for your sponsorship, we allow the sponsor to use the Matroska logo's and trademarks in packaging, physical products, promotional material, and on their websites.
+
+To find out more information, see the [Sponsors](http://matroska.org/node/44) section.
+
 ## creative commons
 
 # Attribution 4.0 International

--- a/contributions.md
+++ b/contributions.md
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+# Contributions
+
+**Licenses**
+
+Matroska [uses a few](http://matroska.org/node/47) open source initiative approved open source licenses to enable availability of source code and to accept contributions from individuals and corporations.
+
+**Contributor License Grants**
+
+All individual contributors of ideas, code, or documentation to Matroska will be required to complete, sign, and submit an [Individual Contributor License Grant](http://matroska.org/technical/contributions/individual-cla.html). The agreement clearly defines the terms under which intellectual property has been contributed to the Matroska. This license is for your protection as a contributor as well as the protection of the project; it does not change your rights to use your own contributions for any other purpose.
+
+For a corporation that has assigned employees to work on Matroska, a [Corporate Contributor License Grant](http://matroska.org/technical/contributions/corporate-cla.html) is available. This version of the Grant allows a corporation to authorize contributions submitted by its designated employees and to grant copyright and patent licenses. Note that a Corporate Contributor License Grant does not remove the need for any developer to sign their own Individual Contributor License Grant as an individual, to cover any of their contributions which are not owned by the corporation signing the Corporate Contributor License Grant.
+
+Please note that we based our grants on the ones that the [Apache Software Foundation](http://www.apache.org/) uses, which can be found on [its site](http://www.apache.org/licenses/).

--- a/cover_art.md
+++ b/cover_art.md
@@ -1,0 +1,20 @@
+---
+layout: default
+---
+
+With the rise of Media Centers and even programs to manage large amounts of audio files, it's becoming necessary to visualize your files easily, not just browse by names. It is also a lot nicer to browse for the user. Matroska supports attachments and they can be used for cover arts. This document defines a set of guidelines for coders and file creators to add cover arts correctly in Matroska files. These guidelines will ensure the user experience is good and consistent wherever you put your files.
+
+The pictures should only use the JPEG and PNG picture formats.
+
+There can be 2 different cover for a movie/album. A portrait one (like a DVD case) and a landscape one (like a banner ad for example, looking better on a wide screen).
+
+There can be 2 versions of the same cover, the normal one and the small one. The dimension of the normal one should be 600 on the smallest side (eg 960x600 for landscape and 600x800 for portrait, 600x600 for square). The dimension of the small one should be 120 (192x120 or 120x160).
+
+The way to differentiate between all these versions is by the filename. The default filename is cover.(png/jpg) for backward compatibility reasons. That is the "big" version of the file (600) in square or portrait mode. It should also be the first file in the attachments. The smaller resolution should be prefixed with "small_", ie small_cover.(jpg/png). The landscape variant should be suffixed with "_land", ie cover_land.jpg. The filenames are case sensitive and should all be lower case.
+
+*   cover.jpg (portrait/square 600)
+*   small_cover.png (portrait/square 120)
+*   cover_land.png (landscape 600)
+*   small_cover_land.jpg (landscape 120)
+
+There is a [sample file](https://sourceforge.net/projects/matroska/files/test_files/cover_art.mkv/download) available to test player compatibility or simply show users how they should add cover art in their Matroska files.

--- a/menu.md
+++ b/menu.md
@@ -1,0 +1,75 @@
+---
+layout: default
+---
+
+# Menu Specifications
+
+# Introduction
+
+This document is a _draft of the Menu system_ that will be the default one in Matroska. As it will just be composed of a Control Track, it will be seen as a "codec" and could be replaced later by something else if needed.
+
+A menu is like what you see on DVDs, when you have some screens to select the audio format, subtitles or scene selection.
+
+# Requirements
+
+What we'll try to have is a system that can do almost everything done on a DVD, or more, or better, or drop the unused features if necessary.
+
+As the name suggests, a Control Track is a track that can control the playback of the file and/or all the playback features. To make it as simple as possible for players, the Control Track will just give orders to the player and get the actions associated with the highlights/hotspots.
+
+## Highlights/Hotspots
+
+A hightlight is basically a rectangle/key associated with an action UID. When that rectangle/key is activated, the player send the UID of the action to the Control Track handler (codec). The fact that it can also be a key means that even for audio only files, a keyboard shortcut or button panel could be used for menues. But in that case, the hotspot will have to be associated with a name to display.
+
+So this hightlight is sent from the Control Track to the Player. Then the player has to handle that highlight until it's disactivated (see [Playback features](#feat))
+
+The hightlight contains a UID of the action, a displayable name (UTF-8), an associated key (list of keys to be defined, probably up/down/left/right/select), a screen position/range and an image to display. The image will be displayed either when the user place the mouse over the rectangle (or any other shape), or when an option of the screen is selected (not activated). There could be a second image used when the option is activated. And there should be a third image that can serve as background. This way you could have a still image (like in some DVDs) for the menu and behind that image blank video (small bitrate).
+
+When a highlight is activated by the user, the player has to send the UID of the action to the Control Track. Then the Control Track codec will handle the action and possibly give new orders to the player.
+
+The format used for storing images should be extensible. For the moment we'll use PNG and BMP, both with alpha channel.
+
+## Playback features
+
+All the following features will be sent from the Control Track to the Player :
+
+*   Jump to chapter (UID, prev, next, number)
+*   Disable all tracks of a kind (audio, video, subtitle)
+*   Enable track UID (the kind doesn't matter)
+*   Define/Disable a highlight
+*   Enable/Disable jumping
+*   Enable/Disable track selection of a kind
+*   Select Edition ID (see chapters)
+*   Pause playback
+*   Stop playback
+*   Enable/Disable a Chapter UID
+*   Hide/Unhide a Chapter UID
+
+All the actions will be writen in a normal Matroska track, with a timecode. A "Menu Frame" should be able to contain more that one action/highlight for a given timecode. (to be determined, EBML format structure)
+
+## Player requirements
+
+Some players might not support the control track. That mean they will play the active/looped parts as part of the data. So I suggest putting the active/looped parts of a movie at the end of a movie. When a Menu-aware player encouter the default Control Track of a Matroska file, the first order should be to jump at the start of the active/looped part of the movie.
+
+# Working Graph
+
+<pre> 
+Matroska Source file -> Control Track <-> Player.
+                     -> other tracks   -> rendered</pre>
+
+# Ideas
+
+<pre> 
+!!!! KNOW Where the main/audio/subs menu starts wherever we are (use chapters) !!!!
+
+!!!! Keep in mind the state of the selected tracks of each kind (more than 1 for each possible) !!!!
+!!!! Order of blending !!!!
+!!!! What if a command is not supported by the player ? !!!!
+!!!! Track selection issue, only applies when 'quiting' the menu (but still possible to change live too) !!!!
+!!!! Allow to hide (not render) some parts of a movie for certain editions !!!!
+!!!! Get the parental level of the player (can be changed live) !!!!
+
+</pre>
+
+# Data Structure
+
+As a Matroska side project, the obvious choice for storing binary data is EBML.

--- a/overhead.md
+++ b/overhead.md
@@ -1,0 +1,162 @@
+# Overhead
+
+One of the way to compare containers is to analyze the overhead produced for the same raw data. The overhead is the amount of data added to these raw data, due to the internal structure of the format.
+
+This document is only giving the overhead introduced by matroska. It is intended for the matroska team to better tune the format for efficiency. And also specify where matroska is best suited.
+
+## Example 1 - low bitrate audio
+
+Low bitrate audio (like speex or vorbis) is usually using very small packets of data, all independent ones (no reference to previous or future frames). The bitrate can be as low as 8kbps (to 64kbps). For 8kbps you have 1kBps. If you cut that into 20ms parts, that makes approximately 100 bytes (to 1000 bytes) per part (packet). Low bitrate codec are usually tuned for real-time conferencing on limited bandwidth lines, so the VBR aspect is usually limited. That's why we will consider that bitrate to be constant, ie the size of packets.
+
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace | 4 in lace | 5 in lace | 6 in lace | 7 in lace |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 8kbps | 100 | 1+1+4+0+100 (6%) | 1+2+4+2+200 (4.5%) | 1+2+4+3+300 (3.3%) | 1+2+4+4+400 (2.8%) | 1+2+4+5+500 (2.4%) | 1+2+4+6+600 (2.2%) | 1+2+4+7+700 (2%) |
+| 16kbps | 200 | 1+2+4+0+200 (3.5%) | 1+2+4+2+400 (2.3%) | 1+2+4+3+600 (1.7%) | 1+2+4+4+800 (1.4%) | 1+2+4+5+1000 (1.2%) | 1+2+4+6+1200 (1.1%) | 1+2+4+7+1400 (1%) |
+| 24kbps | 300 | 1+2+4+0+300 (2%) | 1+2+4+3+600 (1.8%) | 1+2+4+5+900 (1.3%) | 1+2+4+7+1200 (1.2%) | 1+2+4+9+1500 (1.1%) | 1+2+4+11+1800 (1%) | 1+2+4+13+2100 (0.95%) |
+| 32kbps | 400 | 1+2+4+0+400 (1.8%) | 1+2+4+3+800 (1.3%) | 1+2+4+5+1200 (1%) | 1+2+4+7+1600 (0.88%) | 1+2+4+9+2000 (0.8%) | 1+2+4+11+2400 (0.67%) | 1+2+4+13+2800 (0.71%) |
+| 48kbps | 600 | 1+2+4+0+600 (1%) | 1+2+4+4+1200 (0.92%) | 1+2+4+7+1800 (0.78%) | 1+2+4+10+2400 (0.71%) | 1+2+4+13+3000 (0.75%) | 1+2+4+16+3600 (0.64%) | 1+2+4+19+4200 (0.62%) |
+| 64kbps | 800 | 1+2+4+0+800 (0.88%) | 1+2+4+5+1600 (0.75%) | 1+2+4+9+2400 (0.67%) | 1+2+4+13+3200 (0.63%) | 1+2+4+17+4000 (0.60%) | 1+2+4+21+4800 (0.58%) | 1+2+4+26+5600 (0.59%) |
+
+**explanations :** This is the overhead introduced by the Block level. There is more overhead in a matroska file, ie the Cluster head (that contains many Blocks) and the file header (containing various meta information).
+
+the first number is the number is the size of the total Block+Data, ie element ID (1), size (1 to 8), Block head (4), lacing (0 to infinite), data
+
+the second number is the pourcentage of overhead for each packet
+
+In matroska, synchronisation and error recovery is done with a Cluster. A cluster contains 1 to many Blocks. So let's see the effect of having 1 Block per Cluster, 2 Blocks per Cluster and 3 Blocks per Cluster. These are the worst cases where synchronisation is required often, ie every 20, 40 and 60ms (with 1 block only). A value of 1s is a pretty agressive case and is the minimum supported here (just to save me from a few calculus).
+
+| 1 Block per Cluster |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace | 4 in lace | 5 in lace (1s) | 6 in lace (1.2s) | 7 in lace (1.4s) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 8kbps | 100 | 4+2+1+2+4+5+500 (3.6%) | 4+2+1+2+4+6+600 (3.2%) | 4+2+1+2+4+7+700 (2.9%) |
+| 16kbps | 200 | 4+2+1+2+4+5+1000 (1.8%) | 4+2+1+2+4+6+1200 (1.6%) | 4+2+1+2+4+7+1400 (1.4%) |
+| 24kbps | 300 | 4+2+1+2+4+9+1500 (1.5%) | 4+2+1+2+4+11+1800 (1.3%) | 4+2+1+2+4+13+2100 (1.2%) |
+| 32kbps | 400 | 4+2+1+2+4+9+2000 (1.1%) | 4+2+1+2+4+11+2400 (1%) | 4+2+1+2+4+13+2800 (0.93%) |
+| 48kbps | 600 | 4+2+1+2+4+13+3000 (0.87%) | 4+2+1+2+4+16+3600 (0.81%) | 4+2+1+2+4+19+4200 (0.76%) |
+| 64kbps | 800 | 4+2+1+2+4+17+4000 (0.75%) | 4+2+1+2+4+21+4800 (0.71%) | 4+2+1+2+4+26+5600 (0.70%) |
+
+| 2 Blocks per Cluster |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace (0.8s) | 3 in lace (1.2s) | 4 in lace (1.6s) | 5 in lace (2s) | 6 in lace (2.4s) | 7 in lace (2.8s) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 8kbps | 100 | 4+2+2*(1+2+4+2+200) (6%) | 4+2+2*(1+2+4+3+300) (4.3%) | 4+2+2*(1+2+4+4+400) (3.5%) | 4+2+2*(1+2+4+5+500) (3%) | 4+2+2*(1+2+4+6+600) (2.7%) | 4+2+2*(1+2+4+7+700) (2.4%) |
+| 16kbps | 200 | 4+2+2*(1+2+4+2+400) (3%) | 4+2+2*(1+2+4+3+600) (2.2%) | 4+2+2*(1+2+4+4+800) (1.8%) | 4+2+2*(1+2+4+5+1000) (1.5%) | 4+2+2*(1+2+4+6+1200) (1.1%) | 4+2+2*(1+2+4+7+1400) (1%) |
+| 24kbps | 300 | 4+2+2*(1+2+4+3+600) (2.2%) | 4+2+2*(1+2+4+5+900) (1.7%) | 4+2+2*(1+2+4+7+1200) (1.4%) | 4+2+2*(1+2+4+9+1500) (1.3%) | 4+2+2*(1+2+4+11+1800) (1.2%) | 4+2+2*(1+2+4+13+2100) (1.1%) |
+| 32kbps | 400 | 4+2+2*(1+2+4+3+800) (1.6%) | 4+2+2*(1+2+4+5+1200) (1.3%) | 4+2+2*(1+2+4+7+1600) (1.1%) | 4+2+2*(1+2+4+9+2000) (0.95%) | 4+2+2*(1+2+4+11+2400) (0.88%) | 4+2+2*(1+2+4+13+2800) (0.82%) |
+| 48kbps | 600 | 4+2+2*(1+2+4+4+1200) (1.2%) | 4+2+2*(1+2+4+7+1800) (0.94%) | 4+2+2*(1+2+4+10+2400) (0.83%) | 4+2+2*(1+2+4+13+3000) (0.77%) | 4+2+2*(1+2+4+16+3600) (0.72%) | 4+2+2*(1+2+4+19+4200) (0.69%) |
+| 64kbps | 800 | 4+2+2*(1+2+4+5+1600) (0.94%) | 4+2+2*(1+2+4+9+2400) (0.79%) | 4+2+2*(1+2+4+13+3200) (0.72%) | 4+2+2*(1+2+4+17+4000) (0.68%) | 4+2+2*(1+2+4+21+4800) (0.65%) | 4+2+2*(1+2+4+26+5600) (0.64%) |
+
+| 3 Blocks per Cluster |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace (1.2s) | 3 in lace (1.8s) | 4 in lace (2.4s) | 5 in lace (3s) | 6 in lace (3.6s) | 7 in lace (4.2s) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 8kbps | 100 | 4+2+3*(1+2+4+2+200) (5.5%) | 4+2+3*(1+2+4+3+300) (4%) | 4+2+3*(1+2+4+4+400) (3.3%) | 4+2+3*(1+2+4+5+500) (2.8%) | 4+2+3*(1+2+4+6+600) (2.5%) | 4+2+3*(1+2+4+7+700) (2.3%) |
+| 16kbps | 200 | 4+2+3*(1+2+4+2+400) (2.8%) | 4+2+3*(1+2+4+3+600) (2%) | 4+2+3*(1+2+4+4+800) (1.6%) | 4+2+3*(1+2+4+5+1000) (1.4%) | 4+2+3*(1+2+4+6+1200) (1.3%) | 4+2+3*(1+2+4+7+1400) (1.1%) |
+| 24kbps | 300 | 4+2+3*(1+2+4+3+600) (1.8%) | 4+2+3*(1+2+4+5+900) (1.3%) | 4+2+3*(1+2+4+7+1200) (1.2%) | 4+2+3*(1+2+4+9+1500) (1.1%) | 4+2+3*(1+2+4+11+1800) (1%) | 4+2+3*(1+2+4+13+2100) (0.95%) |
+| 32kbps | 400 | 4+2+3*(1+2+4+3+800) (1.5%) | 4+2+3*(1+2+4+5+1200) (1.2%) | 4+2+3*(1+2+4+7+1600) (1%) | 4+2+3*(1+2+4+9+2000) (0.9%) | 4+2+3*(1+2+4+11+2400) (0.83%) | 4+2+3*(1+2+4+13+2800) (0.79%) |
+| 48kbps | 600 | 4+2+3*(1+2+4+4+1200) (0.92%) | 4+2+3*(1+2+4+7+1800) (0.78%) | 4+2+3*(1+2+4+10+2400) (0.71%) | 4+2+3*(1+2+4+13+3000) (0.75%) | 4+2+3*(1+2+4+16+3600) (0.64%) | 4+2+3*(1+2+4+19+4200) (0.62%) |
+| 64kbps | 800 | 4+2+3*(1+2+4+5+1600) (0.88%) | 4+2+3*(1+2+4+9+2400) (0.75%) | 4+2+3*(1+2+4+13+3200) (0.69%) | 4+2+3*(1+2+4+17+4000) (0.65%) | 4+2+3*(1+2+4+21+4800) (0.63%) | 4+2+3*(1+2+4+26+5600) (0.63%) |
+
+**explanations :** the third number is the max time between 2 error recoveries (re-sync) in milliseconds. This is based on the example of all frames have a 20ms granularity.
+
+### Conclusions
+
+*   For the same error-recovery (1.2s, 2.4s) we clearly see that it's better to put as much data in one Block and use lacing. In this case there will be 1 Block per Cluster. One of the drawback is that only the first packet of data has a timecode (one timecode every second).
+*   If we agree that 2% overhead is OK for low bitrates (the same as for MP3), the minimum bitrate acceptable is between 8kbps and 16kbps (probably closer to 16 kbps). Actually this value depend on the block size and not really the bitrate.
+*   For bitrates higher than 48kbps (or a fixed packet rate of 600 bytes) the overhead is very good even with one frame per packet.
+
+## Example 2 - medium bitrate audio
+
+## Example 3 - high bitrate audio
+
+## Example 4 - low bitrate video
+
+Low bitrate video is, like low bitrate audio, the worst case for overhead. The range we will use here is 64 kbps to 256kbps. I think these are reasonable values for what can be considered as low video bitrate.
+
+One of the major difference in video is that the number of frame per second is fixed (10 to 30 for low bitrates).
+
+Another difference is that the frames usually depend on others to save some compression bits. One of the effect is that all frames don't have the same size. You have key frames (I) that don't depend on other frames, (P) frames that depend on an older frame and (B) frames that rely on an older and a future frame.
+
+It is mandatory that all I frames have an actual timecode coming from the container, because the P and B frames will rely on that timecode for reference.
+
+### First example - all I frames (CBR)
+
+With all I frames, the average data is easy to compute. For 64kbps=8kBps we have a frame=1/20s. That means each frame is 400 bytes big. So the results are similar to 32kbps audio.
+
+Lacing should not be used for better seeking in the file. But it is still possible for use in this particular case.
+
+| 1 I frame/Block per Cluster (5ms) |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace |
+| --- | --- | --- | --- | --- |
+| 64kbps | 400 | 4+2+1+2+4+400 (3.3%) | 4+2+1+2+4+3+800 (2%) | 4+2+1+2+4+5+1200 (1.5%) |
+| 128kbps | 800 | 4+2+1+2+4+800 (1.63%) | 4+2+1+2+4+5+1600 (1.1%) | 4+2+1+2+4+9+2400 (0.92%) |
+| 256kbps | 1200 | 4+2+1+2+4+1200 (1.08%) | 4+2+1+2+4+6+2400 (0.79%) | 4+2+1+2+4+11+3600 (0.67%) |
+
+| 2 I frame/Block per Cluster (10ms) |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace |
+| --- | --- | --- | --- | --- |
+| 64kbps | 400 | 4+2+2*(1+2+4+400) (2.5%) | 4+2+2*(1+2+4+3+800) (1.6%) | 4+2+2*(1+2+4+5+1200) (1.3%) |
+| 128kbps | 800 | 4+2+2*(1+2+4+800) (1.3%) | 4+2+2*(1+2+4+5+1600) (0.94%) | 4+2+2*(1+2+4+9+2400) (0.7%) |
+| 256kbps | 1200 | 4+2+2*(1+2+4+1200) (0.83%) | 4+2+2*(1+2+4+6+2400) (0.67%) | 4+2+2*(1+2+4+11+3600) (0.58%) |
+
+| 4 I frame/Block per Cluster (20ms) |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace |
+| --- | --- | --- | --- | --- |
+| 64kbps | 400 | 4+2+4*(1+2+4+400) (2.1%) | 4+2+4*(1+2+4+3+800) (1.4%) | 4+2+4*(1+2+4+5+1200) (1.1%) |
+| 128kbps | 800 | 4+2+4*(1+2+4+800) (1.06%) | 4+2+4*(1+2+4+5+1600) (0.84%) | 4+2+4*(1+2+4+9+2400) (0.73%) |
+| 256kbps | 1200 | 4+2+4*(1+2+4+1200) (0.71%) | 4+2+4*(1+2+4+6+2400) (0.60%) | 4+2+4*(1+2+4+11+3600) (0.54%) |
+
+| 8 I frame/Block per Cluster (40ms) |
+| --- |
+| bitrate | pkt size | No lacing | 2 in lace | 3 in lace |
+| --- | --- | --- | --- | --- |
+| 64kbps | 400 | 4+2+8*(1+2+4+400) (1.9%) | 4+2+8*(1+2+4+3+800) (1.3%) | 4+2+8*(1+2+4+5+1200) (1.06%) |
+| 128kbps | 800 | 4+2+8*(1+2+4+800) (0.97%) | 4+2+8*(1+2+4+5+1600) (0.80%) | 4+2+8*(1+2+4+9+2400) (0.73%) |
+| 256kbps | 1200 | 4+2+8*(1+2+4+1200) (0.65%) | 4+2+8*(1+2+4+6+2400) (0.57%) | 4+2+8*(1+2+4+11+3600) (0.52%) |
+
+We clearly see that there is another more interresting table (lacing use is dropped) :
+
+| bitrate | pkt size | 1 Block/C (50ms) | 2 Blocks/C (100ms) | 4 Blocks/C (200ms) | 8 Blocks/C (400ms) | 16 Blocks/C (800ms) | 20 Blocks/C (1s) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 64kbps | 400 | 4+2+1*(1+2+4+400) (3.3%) | 4+2+2*(1+2+4+400) (2.5%) | 4+2+4*(1+2+4+400) (2.1%) | 4+2+8*(1+2+4+400) (1.9%) | 4+2+16*(1+2+4+400) (1.8%) | 4+2+20*(1+2+4+400) (1.8%) |
+| 128kbps | 800 | 4+2+1*(1+2+4+800) (1.63%) | 4+2+2*(1+2+4+800) (1.3%) | 4+2+4*(1+2+4+800) (1.06%) | 4+2+8*(1+2+4+800) (0.97%) | 4+2+16*(1+2+4+800) (0.92%) | 4+2+20*(1+2+4+800) (0.91%) |
+| 256kbps | 1200 | 4+2+1*(1+2+4+1200) (1.08%) | 4+2+2*(1+2+4+1200) (0.83%) | 4+2+4*(1+2+4+1200) (1.06%) | 4+2+8*(1+2+4+1200) (0.65%) | 4+2+16*(1+2+4+1200) (0.61%) | 4+2+20*(1+2+4+1200) (0.61%) |
+
+**Conslusions :**
+
+*   In most cases, the best result is when 8 Blocks are packed in a Cluster. Bigger values don't improve the overhead much. It also seems to be a good value to stop using lacing in the low audio bitrate example. **So both lacing and clustering will be limited to 8 elements in libmatroska** on writing.
+*   In an agressive case like a 64kbps CBR video codec at 20 frames/sec can still achieve an overhead of less than 2% which is quite good.
+*   Upper 128kbps an overhead of less than 1% can always be achieved.
+*   Having 2 frames in a lace can improve substanctially the overhead. But as I frames should always have a proper timecode, it is not possible to use this solution.
+
+### Second example - 1 I frame for 1 B frame
+
+In this case, each frame has to be separated in a Block (no lacing possible). The reference timecode in matroska (of the previous frame) is written in a separate element ([BlockAddition][TimecodeReference]). So more overhead is introduced.
+
+We will establish that the P frame is 3x smaller than the I frame (I hope this is a realistic case). That means that, at 20 frames per second, for 64 kbps the I frame is 600 bytes and the B frame is 200 bytes (2 frames are 2*400 bytes big).
+
+| bitrate | pkt size | 2 Blocks/C (100ms) | 4 Blocks/C (200ms) | 8 Blocks/C (400ms) | 16 Blocks/C (800ms) | 20 Blocks/C (1s) |
+| --- | --- | --- | --- | --- | --- | --- |
+| 64kbps | 600/200 | 4+2+(1+2+4+600)+(1+2+4+200+1+1+2) (3%) | 4+2+2*((1+2+4+600)+(1+2+4+200+1+1+2)) (2.6%) | 4+2+4*((1+2+4+600)+(1+2+4+200+1+1+2)) (2.4%) | 4+2+8*((1+2+4+600)+(1+2+4+200+1+1+2)) (2.3%) | 4+2+10*((1+2+4+600)+(1+2+4+200+1+1+2)) (2.3%) |
+| 128kbps | 1200/400 | 4+2+(1+2+4+1200)+(1+2+4+400+1+1+2) (1.5%) | 4+2+2*((1+2+4+1200)+(1+2+4+400+1+1+2)) (1.3%) | 4+2+4*((1+2+4+1200)+(1+2+4+400+1+1+2)) (1.2%) | 4+2+8*((1+2+4+1200)+(1+2+4+400+1+1+2)) (1.1%) | 4+2+10*((1+2+4+1200)+(1+2+4+400+1+1+2)) (1.1%) |
+| 256kbps | 1800/600 | 4+2+(1+2+4+1800)+(1+2+4+600+1+1+2) (1.01%) | 4+2+2*((1+2+4+1800)+(1+2+4+600+1+1+2)) (0.88%) | 4+2+4*((1+2+4+1800)+(1+2+4+600+1+1+2)) (0.81%) | 4+2+8*((1+2+4+1800)+(1+2+4+600+1+1+2)) (0.78%) | 4+2+10*((1+2+4+1800)+(1+2+4+600+1+1+2)) (0.78%) |
+
+**Conslusions :**
+
+*   As for the previous case, 8 Blocks per Cluster seem to be the optimum value.
+*   The use of B frame degrades the overhead by approximately 0.5%. It is due to the additional backward reference.
+*   A bitrate of over 128 kbps still have a good overhead. But the 2.4% for 64kbps is still acceptable.
+
+## Example 5 - medium bitrate video
+
+## Example 6 - high bitrate video
+
+## Example 7 - low bitrate video + low bitrate audio
+
+## Example 8 - medium bitrate video + medium bitrate audio
+
+## Example 9 - high bitrate video + high bitrate audio

--- a/overhead.md
+++ b/overhead.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Overhead
 
 One of the way to compare containers is to analyze the overhead produced for the same raw data. The overhead is the amount of data added to these raw data, due to the internal structure of the format.

--- a/source_code_repository.md
+++ b/source_code_repository.md
@@ -1,0 +1,29 @@
+---
+layout: default
+---
+
+# Source Code Repository
+
+## Source Code
+
+### Official releases
+
+There are many ways to get access to the source code. As a 3rd party developper (user) you can download [libmatroska](http://dl.matroska.org/downloads/libmatroska/) and [libebml](http://dl.matroska.org/downloads/libebml/) from there official location in .tar.bz2 format. If you are a Java developer you can checkout JEBML from our [Git repository for a Java Matroska reading library](https://github.com/Matroska-Org/jebml).
+
+### Source code repositories (Git)
+
+We provide the source code to all of our projects in Git repositories hosted on [github.com](https://github.com/Matroska-Org/). There is one repository per project (e.g. [libEBML](https://github.com/Matroska-Org/libebml) and [libMatroska](https://github.com/Matroska-Org/libmatroska)).
+
+You can clone a Git repository with the following command:
+
+`git clone https://github.com/Matroska-Org/repositoryname.git`
+
+e.g. for libMatroska:
+
+`git clone https://github.com/Matroska-Org/libmatroska.git`
+
+### Obsolete repositories
+
+Some of the very old repositories have not been migrated to github.com. The source code for those is still available in our old Subversion repository which you can clone with the following command:
+
+`svn checkout https://matroska.svn.sourceforge.net/svnroot/matroska/trunk/`

--- a/streaming.md
+++ b/streaming.md
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+# Matroska Streaming
+
+There exist multiple ways to stream a content. The term streaming itself is very vague. It means reading a file stored on a server. But the server could be very distant or very close. The transport system and the protocol used for streaming makes the whole difference.
+
+In the case of Matroska, there are mostly 2 different kinds of stream: file access and live streaming.
+
+# File Access
+
+File access can simply be reading a file located on your computer, but also accessing it from an HTTP (web) server or CIFS (windows share) server. All these protocol are usually safe from reading errors and seeking in the stream is possible. On other hand when the file is stored far or on a slow server, seeking can be an expensive operation and should be avoided. That's why we set a [few guidelines](../order/index.html) that, when followed, help reduce the number of seeking for regular playback and also have the playback start quickly without a lot of data needed to read first (like the Cues (index), Attachments or Meta Seek of all the Clusters).
+
+Matroska having a small overhead, it is well suited for storing music/videos on file servers without having a big impact on the bandwidth used. It doesn't require to load the index before playing (the index can be loaded only when seeking is requested the first time), so playback can start very quickly too.
+
+# Live Streaming
+
+Live streaming is the equivalent of TV broadcasting on the internet. There are 2 families of servers for that. The RTP/RTSP ones and the HTTP servers. Matroska is not meant to be used over RTP. RTP already has timing and channel mechanisms that would wasted if doubled in Matroska. On the other hand live streaming of Matroska over HTTP (or any other plain protocol based on TCP) is very possible.
+
+A live Matroska stream is different than a file, because it may have no known end (only when the client disconnects). For that the Segment _must_ use the "unknow" size (all 1s in the size). The other option would be to concatenate Segments with known sizes one after the other. This solution allows a change of codec/resolution between each segment which can be useful in some cases (switch between 4:3 and 16:9 in some TV programs for example).
+
+The Segment(s) being continuous, certain elements like Meta Seek, Cues, Chapters, Attachments _must_ not be used in this context.
+
+On the player side, it is possible to detect that a stream is not seekable. If the stream does not have a Meta Seek list or a Cues list at the beginning of the stream, it _should_ be considered as non seekable. Even though it's still theoretically possible to seek blindly forward in the stream, if the server supports it.
+
+In the context of a live radio or even web TV it should be possible to "Tag" the content that is currently playing. The Tags level 1 element can be placed between Clusters each time necessary. In that case, the new Tags found _must_ reset the previously encountered tags and use the new values instead (be they empty).

--- a/team.md
+++ b/team.md
@@ -1,0 +1,77 @@
+---
+layout: default
+---
+
+This page is a tribute to all the persons who have been involved in the creation of Matroska or related programs, in alphabetical order :
+
+*   Laurent "fenrir" Aimar
+*   Roberto José "rjamorim" de Amorim
+*   Daisuke "ayana" Anayama
+*   Joseph Ashwood
+*   Kathryn Taylor
+*   Moritz "Mosu" Bunkus
+*   Andrew "shatty" Bachmann
+*   Menno Bakker
+*   Alban "albeu" Bedel
+*   Anshuman "golddragongt" Bhairavbhat
+*   Ingo Ralf Blum
+*   Age "Prodoc" Bosma
+*   Martin 'atomic' Braun
+*   Paul "Pamel/Atamido" Bryson
+*   Ronald "BBB" Bultje
+*   John "spyder482" Cannon
+*   Liisachan
+*   Julien "Cyrius" Coolos
+*   Radek "SysKin" Czyz
+*   Luca "kaiousama" Della Santina
+*   Marlena Deren
+*   Martin "md`" Drobek
+*   Eric Oliver Flores
+*   Gabest
+*   Edouard "GomGom" Gomez
+*   Jean-Christophe Haessig
+*   Jon "Milkman.Dan" Hickman
+*   Igor Holodov
+*   "Insolit" from Portugal
+*   "Yudai Ishikawa"
+*   Lasse "Tronic/Toronikku" Kärkkäinen
+*   Jean-Baptiste "jb" KEMPF
+*   Frank Klemm
+*   Philipp "Zyrill" Krueger
+*   David "DaveEL" Leatherdale
+*   Avery "phaeron" Lee
+*   Nicolas "goldenear" Le Guen
+*   Laurens Lenior
+*   Amit Limaye
+*   Steve "robUx4" Lhomme
+*   Dan "Betaboy" Marlin
+*   Mike "Haali" Matsnev
+*   Mike Melanson
+*   Tobias "Belgabor" Minich
+*   Shailesh "slmistri" Mistry
+*   Christoper "xiphmont" Montgomery
+*   Megumi Nakaya
+*   Serguei "Snaar" Narojnyi
+*   Michael Niedermayer
+*   Peter Niemayer
+*   Martin Nilsson
+*   Alexander "alexnoe" Noé
+*   Christophe "Toff" Paris
+*   Francois "mmu_man" Revol
+*   Maxim "slipstream" Ryazanov
+*   Jan "myFUN/kromyx" Schlenker
+*   Tiago Bruno "pixolex" Espírito Santo Silva
+*   Animesh "Anisri" Srivastava
+*   Alex "Foogod" Stewart
+*   Nic Stewart
+*   Robin "nibor" Stocker
+*   Jory "jcsston" Stone
+*   Ludovic "Blacksun" Vialle
+*   Florian "SirElvis" Wagner
+*   Christian HJ Wiesner
+*   ??? "DickD" ??? (Doom9)
+*   ??? "kimmo" ???
+*   ??? "Satsuki Yatoshi"
+*   ??? "Sly / RathO" ???
+
+I may have forgotten some people so if you think you should be in that list, don't hesitate to [contact us](http://www.corecodec.com/Company/CoreCodec-Inc.html).


### PR DESCRIPTION
This concludes the conversion from Matroska.org to a gh-pages-based site. Some of these might be worth having conversations about on the issues page or via CELLAR (the contributing and license pages come to mine -- Github has these features built-in). But I prefer the separation of intellectually different work and having that done in different PRs/issues.