### PR TITLE
Cues should include the last Cluster for easier seeking to the end

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -539,7 +539,7 @@
     <documentation lang="en">The hash algorithm used for the signature. A value of '0' means that the contents have not been signed but only encrypted. Predefined values:<br/> 1 - SHA1-160<br/> 2 - MD5</documentation>
   </element>
   <element name="Cues" path="0*1(\Segment\Cues)" id="0x1C53BB6B" type="master" maxOccurs="1" minver="1">
-    <documentation lang="en">A Top-Level Element to speed seeking access. All entries are local to the Segment. This Element SHOULD be mandatory for non <a href="http://www.matroska.org/technical/streaming/index.hmtl">"live" streams</a>.</documentation>
+    <documentation lang="en">A Top-Level Element to speed seeking access. All entries are local to the Segment. This Element SHOULD be mandatory for non <a href="http://www.matroska.org/technical/streaming/index.hmtl">"live" streams</a>. The last `Cluster` of the `Segment` SHOULD be included in this of `CuePoint`.</documentation>
   </element>
   <element name="CuePoint" path="1*(\Segment\Cues\CuePoint)" id="0xBB" type="master" minOccurs="1" minver="1">
     <documentation lang="en">Contains all information relative to a seek point in the Segment.</documentation>


### PR DESCRIPTION
This is useful especially if the duration is missing for the Segment.