### PR TITLE
add codec specs for DVB subtitles (codec ID S_DVBSUB)

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -358,6 +358,11 @@ Each frame is kept intact, including the CRC32. The header and seektable are dro
 **Description:** Basic image based subtitle format; The subtitles are stored as images, like in the DVD. The timestamp in the block header of matroska indicates the start display time, the duration is set with the Duration element. The full data for the subtitle bitmap is stored in the Block's data section.
 
   
+**Codec ID:** S_DVBSUB  
+**Codec Name:** Digital Video Broadcasting (DVB) subtitles  
+**Description:** This is the graphical subtitle format used in the Digital Video Broadcasting standard. For more information about the storage please look at the [Digital Video Broadcasting (DVB) subtitles in Matroska specifications]({{site.baseurl}}/subtitles.html).
+
+  
 **Codec ID:** S_VOBSUB  
 **Codec Name:** VobSub subtitles  
 **Description:** The same subtitle format used on DVDs. Supoprted is only format version 7 and newer. VobSubs consist of two files, the .idx containing information, and the .sub, containing the actual data. The .idx file is stripped of all empty lines, of all comments and of lines beginning with `alt:` or `langidx:`. The line beginning with `id:` SHOULD be transformed into the appropriate Matroska track language element and is discarded. All remaining lines but the ones containing timestamps and file positions are put into the `CodecPrivate` element.

--- a/subtitles.md
+++ b/subtitles.md
@@ -523,3 +523,30 @@ When TextST subtitles are stored inside Matroska, the only allowed character set
 Each HDMV text subtitle stream in a Blu-ray can use one of a handful of character sets. This information is not stored in the MPEG2 Transport Stream itself but in the accompanying Clip Information file.
 
 Therefore a muxer MUST parse the accompanying Clip Information file. If the information indicates a character set other than UTF-8, it MUST re-encode all text Dialog Presentation Segments from the indicated character set to UTF-8 prior to storing them in Matroska.
+
+
+# Digital Video Broadcasting (DVB) subtitles
+
+The specifications for the Digital Video Broadcasting subtitle bitstream format (short: DVB subtitles) can be found in the document "ETSI EN 300 743 - Digital Video Broadcasting (DVB); Subtitling systems". The storage of DVB subtitles in MPEG transport streams is specified in the document "ETSI EN 300 468 - Digital Video Broadcasting (DVB); Specification for Service Information (SI) in DVB systems".
+
+## Storage of DVB subtitles
+
+### CodecID
+
+The CodecID to use is `S_DVBSUB`.
+
+### CodecPrivate
+
+The CodecPrivate element is five bytes long and has the following structure:
+
+*    2 bytes: composition page ID (bit string, left bit first)
+*    2 bytes: ancillary page ID (bit string, left bit first)
+*    1 byte: subtitling type (bit string, left bit first)
+
+The semantics of these bytes are the same as the ones described in section 6.2.41 "Subtitling descriptor" of ETSI EN 300 468.
+
+### Storage of DVB subtitles in Matroska Blocks
+
+Each Matroska Block consists of one or more DVB Subtitle Segments as described in segment 7.2 "Syntax and semantics of the subtitling segment" of ETSI EN 300 743.
+
+Each Matroska Block SHOULD have a Duration indicating how long the DVB Subtitle Segments in that Block SHOULD be displayed.


### PR DESCRIPTION
This is the graphical subtitle format used by the Digital Video Broadcasting standard. There are several programs that have been writing Matroska files with such tracks for years. mkvmerge has only gained support for it after release 9.7.1.

This pull request makes that storage method official.