### PR TITLE
update the TrackTimecodeScale min and max spec value to match the specs

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -219,7 +219,7 @@
     <documentation lang="en">The period in nanoseconds (not scaled by TimcodeScale)
       between two successive fields at the output of the decoding process (see <a href="http://www.matroska.org/technical/specs/notes.html#DefaultDecodedFieldDuration">the notes</a>)</documentation>
   </element>
-  <element name="TrackTimecodeScale" path="1*1(\Segment\Tracks\TrackEntry\TrackTimecodeScale)" id="0x23314F" type="float" minOccurs="1" maxOccurs="1" minver="0" maxver="0" webm="0" default="0x1p+0" range="&gt; 0x0p+0">
+  <element name="TrackTimecodeScale" path="1*1(\Segment\Tracks\TrackEntry\TrackTimecodeScale)" id="0x23314F" type="float" minOccurs="1" maxOccurs="1" minver="1" maxver="3" webm="0" default="0x1p+0" range="&gt; 0x0p+0">
     <documentation lang="en">DEPRECATED, DO NOT USE. The scale to apply on this track to work at normal speed in relation with other tracks (mostly used to adjust video speed when the audio length differs).</documentation>
   </element>
   <element name="TrackOffset" path="0*1(\Segment\Tracks\TrackEntry\TrackOffset)" id="0x537F" type="integer" maxOccurs="1" minver="0" maxver="0" webm="0" default="0">


### PR DESCRIPTION
It was incorrectly set to 0/0 in commit d649f83355c956cd61f321ca06884ed842161300.