### PR TITLE
mmark doesn't work well with <em></em> sections

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -245,9 +245,9 @@ There is also a "packed" mode (values 13 and 14) which consists of packing 2 fra
 
 For separate tracks, Matroska needs to define exactly which track does what. [TrackOperation]({{site.baseurl}}/index.html#TrackOperation) with [TrackCombinePlanes]({{site.baseurl}}/index.html#TrackCombinePlanes) do that. For more details look at [how TrackOperation works]({{site.baseurl}}/notes.html#track-operation).
 
-<em>The 3D support is still in infancy and may evolve to support more features.</em>
+The 3D support is still in infancy and may evolve to support more features.
 
-<em>The [StereoMode]({{site.baseurl}}/index.html#StereoMode) used to be part of Matroska v2 but it didn't meet the requirement for multiple tracks. There was also a bug in libmatroska prior to 0.9.0 that would save/read it as 0x53B9 instead of 0x53B8. Readers may support these legacy files by checking Matroska v2 or 0x53B9. The <a href="http://www.matroska.org/node/1/revisions/74/view#StereoMode">olders values</a> were 0: mono, 1: right eye, 2: left eye, 3: both eyes</em>
+The [StereoMode]({{site.baseurl}}/index.html#StereoMode) used to be part of Matroska v2 but it didn't meet the requirement for multiple tracks. There was also a bug in libmatroska prior to 0.9.0 that would save/read it as 0x53B9 instead of 0x53B8. Readers may support these legacy files by checking Matroska v2 or 0x53B9. The <a href="http://www.matroska.org/node/1/revisions/74/view#StereoMode">olders values</a> were 0: mono, 1: right eye, 2: left eye, 3: both eyes.
 
 # Track Operation
 


### PR DESCRIPTION
We don't really need them anyway

This fixes the build for me (along with the layout: lines fix).

There are still a lot of warnings though.