### PR TITLE
avoid reference to ffv1 version 2

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -248,7 +248,7 @@ Codec Name: FF Video Codec 1
 
 Description: FFV1 is a lossless intra-frame video encoding format designed to efficiently compress video data in a variety of pixel formats. Compared to uncompressed video, FFV1 offers storage compression, frame fixity, and self-description, which makes FFV1 useful as a preservation or intermediate video format. [Draft FFV1 Specification](https://datatracker.ietf.org/doc/draft-niedermayer-cellar-ffv1/)
 
-Initialisation: For FFV1 versions 2 or less, `Private Data` SHOULD NOT be written. For FFV1 version 3 and greater, the `Private Data` MUST contain the FFV1 Configuration Record structure, as defined in https://tools.ietf.org/html/draft-niedermayer-cellar-ffv1-01#section-4.1, and no other data.
+Initialisation: For FFV1 versions 0 or 1, `Private Data` SHOULD NOT be written. For FFV1 version 3 or greater, the `Private Data` MUST contain the FFV1 Configuration Record structure, as defined in https://tools.ietf.org/html/draft-niedermayer-cellar-ffv1-01#section-4.1, and no other data.
 
 ## Audio Codec Mappings
 


### PR DESCRIPTION
This patch considers the conversation at http://ffmpeg.org/pipermail/ffmpeg-devel/2017-March/207699.html. Here it avoids reference to FFV1 version 2 which is not described by the FFV1 specification. It is rewritten to say that FFV1 versions 0 and 1 do not have private data, but that version 3 does have private data.