### PR TITLE
add ebml header/global elements to ebml schema

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <EBMLSchema docType="matroska" version="4">
+  <!-- constraints on EBML Header Elements -->
+  <element name="EBMLMaxIDLength" path="1*1(\EBML\EBMLMaxIDLength)" id="0x42F2" minOccurs="1" maxOccurs="1" range="4" default="4" type="uinteger"/>
+  <element name="EBMLMaxSizeLength" path="1*1(\EBML\EBMLMaxSizeLength)" id="0x42F3" minOccurs="1" maxOccurs="1" range="1-8" default="8" type="uinteger"/>
+  <!-- Root Element-->
   <element name="Segment" path="1*1(\Segment)" id="0x18538067" type="master" unknownsizeallowed="1" minOccurs="1" maxOccurs="1" minver="1">
     <documentation lang="en">The Root Element that contains all other Top-Level Elements (Elements defined only at Level 1). A Matroska file is composed of 1 Segment.</documentation>
   </element>

--- a/index.md
+++ b/index.md
@@ -63,7 +63,7 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 - The `docType` of the `EBML Header` MUST be 'matroska'.
 - The `EBMLMaxIDLength` of the `EBML Header` MUST be `4`.
-- The `EBMLMaxSizeLength` of the `EBML Header` MUST be `8` or less.
+- The `EBMLMaxSizeLength` of the `EBML Header` MUST be between `1` and `8` inclusive.
 
 ## Matroska Design
 


### PR DESCRIPTION
As discussed at
https://github.com/Matroska-Org/ebml-specification/issues/128. This is
the same as added to the ebml specification’s example of ebml schema,
except Matroska adds a header constaint for EBMLMaxSizeLength to say
that the range should be ‘1-8’ rather than ‘not 0’.