### PR TITLE
move the `layout: default` outside of each MarkDown file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # License

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ebml_matroska_elements4rfc.md: ebml_matroska.xml transforms/ebml_schema2markdown
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl ebml_matroska.xml > $@
 
 $(OUTPUT).md: rfc_frontmatter.md index.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md notes.md order_guidelines.md codec_specs.md chapters.md subtitles.md tagging.md attachments.md cues.md streaming.md menu.md
-	cat $^ | grep -v '^---\|^layout:' > $@
+	cat $^ > $@
 
 %.xml: %.md
 	mmark -xml2 -page $< > $@

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,10 @@ github_username:
 
 # Build settings
 markdown: kramdown
+
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"

--- a/attachments.md
+++ b/attachments.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Attachments

--- a/chapters.md
+++ b/chapters.md
@@ -1,6 +1,6 @@
 ---
-layout: default
 ---
+
 #Chapters
 
 ## Edition and Chapter Flags

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1,6 +1,6 @@
 ---
-layout: default
 ---
+
 # Codec Mappings
 
 A `Codec Mapping` is a set of attributes to identify, name, and contextualise the format and characteristics of encoded data that can be contained within Matroska Clusters.
@@ -714,3 +714,4 @@ Codec ID: B_VOBBTN
 Codec Name: VobBtn Buttons
 
 Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html). The file contains a header consisting of the string "butonDVD" followed by the width and height in pixels (16 bits integer each) and 4 reserved bytes. The rest is full [PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html).
+

--- a/cues.md
+++ b/cues.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Cues

--- a/diagram.md
+++ b/diagram.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Matroska Structure

--- a/index.md
+++ b/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Introduction

--- a/menu.md
+++ b/menu.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Menu Specifications

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 If you intend to implement a Matroska player, make sure you can handle all the files in [our test suite](http://www.matroska.org/downloads/test_w1.html), or at least the features presented there, not necessarily the same codecs.

--- a/order_guidelines.md
+++ b/order_guidelines.md
@@ -1,6 +1,6 @@
 ---
-layout: default
 ---
+
 # Matroska Element Ordering Guidelines
 
 Except for the EBML Header and the CRC-32 Element, the EBML specification does not require any particular storage order for Elements. The Matroska specification however defines mandates and recommendations for ordering certain Elements in order to facilitate better playback, seeking, and editing efficiency. This section describes and offers rationale for ordering requirements and recommendations for Matroska.
@@ -65,6 +65,7 @@ The `Tags` Element is the one that is most subject to changes after the file was
 * Tags
 
 ## Optimum layout with Cues at the front
+
 * SeekHead
 * Info
 * Tracks
@@ -77,3 +78,4 @@ The `Tags` Element is the one that is most subject to changes after the file was
 ## Cluster Timecode
 
 As each `BlockGroup` and `SimpleBlock` of a `Cluster` Element needs the Cluster `Timecode`, the `Timecode` Element MUST occur as the first Child Element within the `Cluster` Element.
+

--- a/rfc_frontmatter.md
+++ b/rfc_frontmatter.md
@@ -33,3 +33,4 @@
 This document defines the Matroska audiovisual container, including definitions of its structural Elements, as well as its terminology, vocabulary, and application.
 
 {mainmatter}
+

--- a/source_code_repository.md
+++ b/source_code_repository.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Source Code Repository

--- a/streaming.md
+++ b/streaming.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Matroska Streaming

--- a/subtitles.md
+++ b/subtitles.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Subtitles

--- a/tagging-audio-example.md
+++ b/tagging-audio-example.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Audio Tags Example

--- a/tagging-video-example.md
+++ b/tagging-video-example.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Video Tags Example

--- a/tagging.md
+++ b/tagging.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Tagging
@@ -238,3 +237,4 @@ TERMS_OF_USE         | UTF-8  | The terms of use for this item. This is akin to 
 ## Notes
 
 * In the Target list, a logical OR is applied on all tracks, a logical OR is applied on all chapters. Then a logical AND is applied between the Tracks list and the Chapters list to know if an element belongs to this Target.
+

--- a/team.md
+++ b/team.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 This page is a tribute to all the persons who have been involved in the creation of Matroska or related programs, in alphabetical order :

--- a/wavpack.md
+++ b/wavpack.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 ---
 
 # Matroska Codec - WavPack


### PR DESCRIPTION
That will avoid a cleaning of Markdown files when generating IETF documents
Some extra lines were needed here and there.

And it works locally. Not 100% sure it will work with github pages.