### PR TITLE
adds make dependencies and instructions for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 This repository holds content related to the official Matroska specification and standard. Discussion of the plans for standardization is regulated on the [CELLAR listserv](https://datatracker.ietf.org/wg/cellar/charter/). Approved changes should be submitted to this repository as a pull request. The latest draft published from these specifications can be found at the [IETF Datatracker](https://datatracker.ietf.org/doc/draft-lhomme-cellar-matroska/).
 
+## About this repository
+
+Local versions of the specification can be generated based on code in the `Makefile` directory and related dependencies. The dependencies required are `mmark` and `xml2rfc`. `mmark` is a Markdown processor written in Go, available [here](https://github.com/miekg/mmark) or, for Homebrew users, can be installed with `brew install mmark`. Installation instructions for `xml2rfc` (an XML-to-IETF-draft translator written in Python) are available on the [IETF Tools page](https://tools.ietf.org/tools/).
+
+To create local copies of the RFC in .txt, .md, and .html format, run `make`.
+
+To create a local copy of the website, run `make website`. This command has additional dependencies. See the "About this site" section below for installing and local rendering.
+
+To remove generated specifications, run `make clean`.
+
 ## About this site
 
-This site runs on [Github Pages](https://pages.github.com/) powered by [Jekyll](https://github.com/jekyll/jekyll/blob/master/README.markdown). Approved changes made to the gh-pages branch of this repository can be viewed instantly on the [associated webpage](http://matroska-org.github.io/matroska-specification/).
+This site runs on [Github Pages](https://pages.github.com/) powered by [Jekyll](https://github.com/jekyll/jekyll/blob/master/README.markdown). Approved changes made to the `master` branch of this repository can be viewed instantly on the [associated webpage](http://matroska-org.github.io/matroska-specification/).
 
 If this repository is cloned onto a local machine, it can be run locally. Jekyll runs on Ruby. Like many Ruby projects, it will require that Ruby is installed on the machine. Bundler, a popular Ruby package manager gem, can be used to install the other gem-based dependencies. After these are loaded properly, a local preview of any changes can be viewed by running `jekyll serve` on the command line. Jekyll provides more in-depth options for local usage [in their docs](https://jekyllrb.com/docs/usage/).
 


### PR DESCRIPTION
No related issue, but this updates the matroska-specification README with instructions to make it easier for new people to get involved and build/test locally.