### PR TITLE
clears language in index_codec, index_matroska, index_tags

### DIFF
--- a/index_codec.md
+++ b/index_codec.md
@@ -33,15 +33,15 @@
 
 .# Abstract
 
-This document defines the Matroska codec mappings, including the codec ID, layout of data in a `Block` and in an optinal `CodecPrivate`.
+This document defines the Matroska codec mappings, including the codec ID, layout of data in a `Block Element` and in an optional `CodecPrivate Element`.
 
 {mainmatter}
 
 # Introduction
 
-Matroska aims to become THE standard of multimedia container formats. It stores interleaved and timestamped audio/video/subtitle data using various codec. To interpret the codec data, a mapping between the way the data are stored in Matroska and how they are understood by such codec is necessary.
+Matroska aims to become THE standard of multimedia container formats. It stores interleaved and timestamped audio/video/subtitle data using various codecs. To interpret the codec data, a mapping between the way the data is stored in Matroska and how it is understood by such a codec is necessary.
 
-This document intends to define this mapping for many commonly used codec in Matroska.
+This document intends to define this mapping for many commonly used codecs in Matroska.
 
 # Status of this document
 
@@ -49,7 +49,7 @@ This document is a work-in-progress specification defining the Matroska file for
 
 # Security Considerations
 
-Matroska Codecs inherits security considerations from EBML and Matroska.
+This document inherits security considerations from the EBML and Matroska documents.
 
 # IANA Considerations
 
@@ -58,4 +58,3 @@ To be determined.
 # Notations and Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -33,7 +33,7 @@
 
 .# Abstract
 
-This document defines the Matroska audiovisual container, including definitions of its structural Elements, as well as its terminology, vocabulary, and application.
+This document defines the Matroska audiovisual container, including definitions of its structural elements, as well as its terminology, vocabulary, and application.
 
 {mainmatter}
 
@@ -174,9 +174,13 @@ For (possibly) Laced Data
 
 ### Lacing
 
-Lacing is a mechanism to save space when storing data. It is typically used for small blocks of data (refered to as frames in matroska). There are 3 types of lacing : the Xiph one inspired by what is found in the Ogg container, the EBML one which is the same with sizes coded differently and the fixed-size one where the size is not coded. As an example is better than words...
+Lacing is a mechanism to save space when storing data. It is typically used for small blocks of data (referred to as frames in Matroska). There are 3 types of lacing:
 
-Let's say you want to store 3 frames of the same track. The first frame is 800 octets long, the second is 500 octets long and the third is 1000 octets long. As these data are small, you can store them in a lace to save space. They will then be solved in the same block as follows:
+1. Xiph, inspired by what is found in the Ogg container
+2. EBML, which is the same with sizes coded differently
+3. fixed-size, where the size is not coded
+
+For example, a user wants to store 3 frames of the same track. The first frame is 800 octets long, the second is 500 octets long and the third is 1000 octets long. As these data are small, they can be stored in a lace to save space. They will then be stored in the same block as follows:
 
 #### Xiph lacing
 
@@ -191,7 +195,7 @@ A frame with a size multiple of 255 is coded with a 0 at the end of the size, fo
 
 #### EBML lacing
 
-In this case the size is not coded as blocks of 255 bytes, but as a difference with the previous size and this size is coded as in EBML. The first size in the lace is unsigned as in EBML. The others use a range shifting to get a sign on each value :
+In this case, the size is not coded as blocks of 255 bytes, but as a difference with the previous size and this size is coded as in EBML. The first size in the lace is unsigned as in EBML. The others use a range shifting to get a sign on each value:
 
 Bit Representation                                                          | Value
 :---------------------------------------------------------------------------|:-------
@@ -212,7 +216,7 @@ Bit Representation                                                          | Va
 
 #### Fixed-size lacing
 
-In this case only the number of frames in the lace is saved, the size of each frame is deduced from the total size of the Block. For example, for 3 frames of 800 octets each :
+In this case, only the number of frames in the lace is saved, the size of each frame is deduced from the total size of the Block. For example, for 3 frames of 800 octets each:
 
 *   Block head (with lacing bits set to 10)
 *   Lacing head: Number of frames in the lace -1, i.e. 2
@@ -223,7 +227,7 @@ In this case only the number of frames in the lace is saved, the size of each fr
 
 #### SimpleBlock Structure
 
-The SimpleBlock is very inspired by the [Block structure](#block-structure). The main differences are the added Keyframe flag and Discardable flag. Otherwise everything is the same.
+The `SimpleBlock` is inspired by the [Block structure](#block-structure). The main differences are the added Keyframe flag and Discardable flag. Otherwise everything is the same.
 
 Size = 1 + (1-8) + 4 + (4 + (4)) octets. So from 6 to 21 octets.
 
@@ -231,7 +235,7 @@ Bit 0 is the most significant bit.
 
 Frames using references SHOULD be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timecodes MAY NOT be consecutive. But a frame with a past timecode MUST reference a frame already known, otherwise it's considered bad/void.
 
-There can be many Blocks in a BlockGroup provided they all have the same timecode. It is used with different parts of a frame with different priorities.
+There can be many `Block Elements` in a `BlockGroup` provided they all have the same timecode. It is used with different parts of a frame with different priorities.
 
 ##### SimpleBlock Header
 

--- a/index_tags.md
+++ b/index_tags.md
@@ -39,17 +39,17 @@ This document defines the Matroska tags, namely the tag names and their respecti
 
 # Introduction
 
-Matroska aims to become THE standard of multimedia container formats. It can store timestamped multimedia data but also chapters and tags. The tags add important metadata to indentify and classify the information found in a Matroska Segment. It can tag a whole Segment, separate Tracks, individual Chapters or Attachments.
+Matroska aims to become THE standard of multimedia container formats. It can store timestamped multimedia data but also chapters and tags. The `Tag Elements` add important metadata to identify and classify the information found in a `Matroska Segment`. It can tag a whole `Segment`, separate `Track Elements`, individual `Chapter Elements` or `Attachment Elements`.
 
 While the Matroska tagging framework allows anyone to create their own custom tags, it's important to have a common set of values for interoperability. This document intends to define a set of common tag names used in Matroska.
 
 # Status of this document
 
-This document is a work-in-progress specification defining the Matroska file format as part of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/). It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup.
+This document is a work-in-progress specification defining the Matroska file format as part of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/). It uses basic elements and concepts already defined in the Matroska specifications defined by this workgroup.
 
 # Security Considerations
 
-Tag values can be either strings or binary blobs. Matroska Codecs inherits security considerations from EBML and Matroska.
+`Tag` values can be either strings or binary blobs. This document inherits security considerations from the EBML and Matroska documents.
 
 # IANA Considerations
 
@@ -58,4 +58,3 @@ To be determined.
 # Notations and Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-


### PR DESCRIPTION
Following up on @robUx4's work in splitting, some typo clarifications, backticking, and replacing second-person ("you") language.

A separate PR will come along for tagging-video-example, tagging-audio-example.