### PR TITLE
builds schema at top level, rm extra sublevel in diagram

### DIFF
--- a/diagram.md
+++ b/diagram.md
@@ -41,8 +41,6 @@ The following diagram represents a simple Matroska file, comprised of an `EBML D
 +---------------------------+
 ```
 
-## Matroska Top Level Elements
-
 The Matroska `EBML Schema` defines eight `Top Level Elements`: `SeekHead`, `Info`, `Tracks`, `Chapters`, `Cluster`, `Cues`, `Attachments`, and `Tags`.
 
 The `SeekHead Element` (also known as `MetaSeek`) contains an index of `Top Level Elements` locations within the `Segment`. Use of the `SeekHead Element` is RECOMMENDED. Without a `SeekHead Element`, a Matroska parser would have to search the entire file to find all of the other `Top Level Elements`. This is due to Matroska's flexible ordering requirements; for instance, it is acceptable for the `Chapters Element` to be stored after the `Cluster Elements`.

--- a/matroska_schema_section_header.md
+++ b/matroska_schema_section_header.md
@@ -1,3 +1,4 @@
+
 # Matroska Schema
 
 This specification includes an `EBML Schema` which defines the Elements and structure of Matroska as an EBML Document Type. The EBML Schema defines every valid Matroska element in a manner defined by the EBML specification.


### PR DESCRIPTION
Hello!

The built specification was not considering the schema to be as important as it is. Adding this one extra linebreak causes it to correct itself. I also took out an extra level-2 header in diagram.md because it stands fine on its own. If level-2 headers are recommended for this section, I think more than one should be added (like one for each diagram section).