### PR TITLE
moves notes to end of built specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).xml $(OUT
 ebml_matroska_elements4rfc.md: ebml_matroska.xml transforms/ebml_schema2markdown4rfc.xsl
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl ebml_matroska.xml > $@
 
-$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md notes.md order_guidelines.md chapters.md attachments.md cues.md streaming.md menu.md
+$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md order_guidelines.md chapters.md attachments.md cues.md streaming.md menu.md notes.md
 	cat $^ | grep -v '^---' > $@
 
 $(OUTPUT_CODEC).md: index_codec.md codec_specs.md subtitles.md


### PR DESCRIPTION
Proposal to move notes.md to the end of the build. This section needs a bit of work, maybe should be added to other sections, so it seems right to stick it "at the end" for now.