### PR TITLE
Drop the word "Guidelines" from the element ordering section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).xml $(OUT
 ebml_matroska_elements4rfc.md: ebml_matroska.xml transforms/ebml_schema2markdown4rfc.xsl
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl ebml_matroska.xml > $@
 
-$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md order_guidelines.md chapters.md attachments.md cues.md streaming.md menu.md notes.md
+$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md chapters.md attachments.md cues.md streaming.md menu.md notes.md
 	cat $^ | grep -v '^---' > $@
 
 $(OUTPUT_CODEC).md: index_codec.md codec_specs.md subtitles.md

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,7 +10,7 @@
 <li><a href="{{ site.baseurl }}/diagram.html" title="Diagram">Diagram</a></li>
 <li><a href="{{ site.baseurl }}/index.html" title="Matroska - Specifications">Specifications</a></li>
 <li><a href="{{ site.baseurl }}/notes.html" title="Specification Notes">Specification Notes</a></li>
-<li><a href="{{ site.baseurl }}/order_guidelines.html" title="EBML Elements Order Guidelines">Order Guidelines</a></li>
+<li><a href="{{ site.baseurl }}/ordering.html" title="EBML Element Ordering">Element Ordering</a></li>
 <li><a href="{{ site.baseurl }}/codec_specs.html" title="Codec Specs">Codec Specs</a></li>
 <li><a href="{{ site.baseurl }}/chapters.html" title="Chapter Specifications">Chapters</a></li>
 <li><a href="{{ site.baseurl }}/subtitles.html" title="Subtitles">Subtitles</a></li>

--- a/ordering.md
+++ b/ordering.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# Matroska Element Ordering Guidelines
+# Matroska Element Ordering
 
 Except for the `EBML Header` and the `CRC-32 Element`, the EBML specification does not require any particular storage order for `Elements`. The Matroska specification however defines mandates and recommendations for ordering certain `Elements` in order to facilitate better playback, seeking, and editing efficiency. This section describes and offers rationale for ordering requirements and recommendations for Matroska.
 


### PR DESCRIPTION
Many of the things in that section are requirements, not guidelines.