### PR TITLE
README - adds xsltproc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository holds content related to the official Matroska specification and
 
 ## About this repository
 
-Local versions of the specification can be generated based on code in the `Makefile` directory and related dependencies. The dependencies required are `mmark` and `xml2rfc`. `mmark` is a Markdown processor written in Go, available [here](https://github.com/miekg/mmark) or, for Homebrew users, can be installed with `brew install mmark`. Installation instructions for `xml2rfc` (an XML-to-IETF-draft translator written in Python) are available on the [IETF Tools page](https://tools.ietf.org/tools/).
+Local versions of the specification can be generated based on code in the `Makefile` directory and related dependencies. The dependencies required are `mmark`, `xml2rfc` and `xsltproc`. `mmark` is a Markdown processor written in Go, available [here](https://github.com/miekg/mmark) or, for Homebrew users, can be installed with `brew install mmark`. Installation instructions for `xml2rfc` (an XML-to-IETF-draft translator written in Python) are available on the [IETF Tools page](https://tools.ietf.org/tools/). `xsltproc` is a command line tool for applying XSLT stylesheets to XML documents. 
 
 To create local copies of the RFC in .txt, .md, and .html format, run `make`.
 


### PR DESCRIPTION
Seems like `xsltproc` is not installed on Ubuntu 16.04 by default. I'm not sure of installation instructions for OSX, perhaps it comes pre-installed?