### PR TITLE
Improve the AV1 Encryption description

### DIFF
--- a/codec/av1.md
+++ b/codec/av1.md
@@ -145,13 +145,11 @@ Matroska uses `CuePoints` for seeking. Each `Block` can be referenced in the `Cu
 
 # Encryption
 
-The Encryption scheme is similar to the one used for WebM, using the `ContentEncryption` field and extra `ContentEncAESSettings` and `AESSettingsCipherMode`.
+The Encryption scheme is similar to the one used for WebM, using the `ContentEncryption` field and extra `ContentEncAESSettings` and `AESSettingsCipherMode`. Only the Subsample encryption mode SHOULD be used when encryption is needed.
 
-There are 2 modes of Block encryption: Unencrypted and Subsample encryption.
+The OBUs found in the `Block` SHOULD only encrypt the OBU payload. The payload of `Sequence Header OBUs` and `Metadata OBUs` SHOULD NOT be encrypted.
 
-In the Subsample encryption mode, the OBUs found in the `Block` SHOULD only encrypt the OBU payload. The payload of `Sequence Header OBUs` and `Metadata OBUs` SHOULD NOT be encrypted.
-
-Tile Group OBUs, Frame OBUs and Tile List OBUs SHOULD be encrypted using Subsample Encryption.
+Tile Group OBUs, Frame OBUs and Tile List OBUs SHOULD be encrypted.
 
 
 # More TrackEntry mappings
@@ -309,6 +307,8 @@ AV1 Codec ISO Media File Format Binding: https://aomediacodec.github.io/av1-isob
 
 ## WebM Container
 Official Specification based on the Matroska specifications: https://www.webmproject.org/docs/container/
+
+The WebM encryption documentation: https://www.webmproject.org/docs/webm-encryption/
 
 
 # Document version

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -151,7 +151,17 @@ The OBUs found in a `Block` MUST NOT encrypt the OBU header and size. OBUs of ty
 
 OBUs of type `OBU_METADATA` MAY not be encrypted.
 
-OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` MUST be encrypted.
+OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` MUST be encrypted. Within Tile Group OBUs or Frame OBUs, the following applies:
+
+* A subsample MUST be created for each tile.
+
+* BytesOfProtectedData MUST be a multiple of 16 bytes.
+
+* BytesOfProtectedData MUST end on the last byte of the decode_tile structure (including any trailing bits).
+
+* BytesOfProtectedData MUST span all complete 16-byte blocks of the decode_tile structure (including any trailing bits).
+
+* All other parts of Tile Group OBUs and Frame OBUs MUST be unprotected.
 
 
 # More TrackEntry mappings

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -147,9 +147,11 @@ Matroska uses `CuePoints` for seeking. Each `Block` can be referenced in the `Cu
 
 The Encryption scheme is similar to the one used for WebM, using the `ContentEncryption` field and extra `ContentEncAESSettings` and `AESSettingsCipherMode`. Only the Subsample encryption mode SHOULD be used when encryption is needed.
 
-The OBUs found in the `Block` SHOULD only encrypt the OBU payload. The payload of `Sequence Header OBUs` and `Metadata OBUs` SHOULD NOT be encrypted.
+The OBUs found in a `Block` MUST NOT encrypt the OBU header and size. OBUs of type `OBU_SEQUENCE_HEADER`, `OBU_TEMPORAL_DELIMITER`, `OBU_FRAME_HEADER`, `OBU_REDUNDANT_FRAME_HEADER` and `OBU_PADDING` MUST NOT be encrypted.
 
-Tile Group OBUs, Frame OBUs and Tile List OBUs SHOULD be encrypted.
+OBUs of type `OBU_METADATA` MAY not be encrypted.
+
+OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` MUST be encrypted.
 
 
 # More TrackEntry mappings


### PR DESCRIPTION
Bring it closer to both WebM and ISOBMFF which are both using ISO 23001 Common Encryption.

- only Subsampling found in WebM is used (no unencrypted or fully encrytpted Blocks).
- the same parts are required to be/not be encrypted as in ISOBMFF