### PR TITLE
Sequence header same within sequence not bitstream

### DIFF
--- a/codec/av1.md
+++ b/codec/av1.md
@@ -14,7 +14,7 @@ A Matroska element to store a Frame. Can also be a `SimpleBlock` when not inside
 The name used to describe a codec in Matroska.
 
 ## CVS
-A Coded Video Sequence is a sequence of `Temporal Units` where the contents of __[sequence_header_obu]__ must be bit-identical for all the `Sequence Header OBUs` found in the bitstream before Matroska encapsulation except for the contents of __[operating_parameters_info]__. A `Sequence Header OBU` made of all the identical bits in the CVS is referred to a the `CVS Sequence Header OBU`.
+A Coded Video Sequence is a sequence of `Temporal Units` where the contents of __[sequence_header_obu]__ must be bit-identical for all the `Sequence Header OBUs` found in the sequence before Matroska encapsulation except for the contents of __[operating_parameters_info]__. A `Sequence Header OBU` made of all the identical bits in the CVS is referred to a the `CVS Sequence Header OBU`.
 
 ## CodecPrivate
 Extra data store in Matroska and passed to the decoder before decoding starts. It can also be used to store the profiles and other data to better identify the codec.


### PR DESCRIPTION
Sequence headers must be identical within a sequence, but a bitstream may contain more than one sequence.