### PR TITLE
Av1 encryption sections

### DIFF
--- a/codec/av1.md
+++ b/codec/av1.md
@@ -176,9 +176,11 @@ Within a protected `Block`, the following constraints apply to all the OBUs it c
 
 * OBUs of type `OBU_METADATA` MAY be encrypted.
 
-* OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` are partially encrypted. Within such OBUs, the following applies:
+* OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` are partially encrypted:
 
-    * An encrypted partition MUST be created for each tile whose __[decode_tile]__ structure size (including any trailing bits) is larger or equal to 16 bytes. Smaller __[decode_tile]__ structures MUST NOT be encrypted.
+    * Each __[decode_tile]__ structure (including any trailing bits) MUST be encrypted. An encrypted section is created for each __[decode_tile]__ structure. The section constraints previously defined apply.
+
+    * The rest of the OBU content MUST NOT be encrypted.
 
 
 # More TrackEntry mappings

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -174,13 +174,13 @@ Within a protected `Block`, the following constraints apply to all the OBUs it c
 
 * OBUs of type `OBU_TEMPORAL_DELIMITER`, `OBU_SEQUENCE_HEADER`, `OBU_FRAME_HEADER` (including within an `OBU_FRAME`), `OBU_REDUNDANT_FRAME_HEADER` and `OBU_PADDING` MUST NOT be encrypted.
 
-* OBUs of type `OBU_METADATA` MAY be encrypted.
-
 * OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` are partially encrypted:
 
     * Each __[decode_tile]__ structure (including any trailing bits) MUST be encrypted. An encrypted section is created for each __[decode_tile]__ structure. The section constraints previously defined apply.
 
     * The rest of the OBU content MUST NOT be encrypted.
+
+* OBUs of type `OBU_METADATA` MAY be encrypted. The OBU content being an encrypted section in that case.
 
 
 # More TrackEntry mappings

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -156,6 +156,16 @@ Protected `Blocks` MUST be exactly spanned by one or more contiguous partitions.
 
 Within a protected `Block`, the following constraints apply to all the OBUs it contains:
 
+* Encrypted partitions MUST be a multiple of 16 bytes.
+
+* Encrypted partitions MUST end on the last byte of the merged encrypted sections.
+
+* For merged encrypted sections that are not a multiple of 16 bytes:
+
+    * If the total merged size is smaller than 16 bytes, the merged sections MUST NOT be encrypted and be merged in the preceding clear partition.
+
+    * If the total merged size is bigger than 16 bytes, the remainder bytes at the beginning of the merged section that do not match the 16-bytes alignment MUST NOT be encrypted and be merged to the preceding clear partition. As a result the encrypted partition MAY NOT start at the merged section, but some number of bytes following that.
+
 * All __[obu_header]__ structures and associated __[obu_size]__ fields MUST NOT be encrypted.
 
 * OBUs of type `OBU_TEMPORAL_DELIMITER`, `OBU_SEQUENCE_HEADER`, `OBU_FRAME_HEADER` (including within an `OBU_FRAME`), `OBU_REDUNDANT_FRAME_HEADER` and `OBU_PADDING` MUST NOT be encrypted.
@@ -164,15 +174,7 @@ Within a protected `Block`, the following constraints apply to all the OBUs it c
 
 * OBUs of type `OBU_FRAME` and `OBU_TILE_GROUP` are partially encrypted. Within such OBUs, the following applies:
 
-    * Encrypted partitions MUST be a multiple of 16 bytes.
-
     * An encrypted partition MUST be created for each tile whose __[decode_tile]__ structure size (including any trailing bits) is larger or equal to 16 bytes. Smaller __[decode_tile]__ structures MUST NOT be encrypted.
-
-    * Encrypted partitions MUST end on the last byte of the __[decode_tile]__ structure (including any trailing bits).
-
-    * Encrypted partitions MUST span all complete 16-byte blocks of the __[decode_tile]__ structure (including any trailing bits).
-
-    * Bytes at the beginning of the __[decode_tile]__ that do not fit in the 16-bytes encrypted partitions SHOULD be added to the preceding unprotected partition. As a result the Encrypted partitions MAY NOT start at the first byte of the __[decode_tile]__ structure, but some number of bytes following that.
 
 
 # More TrackEntry mappings

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -149,9 +149,11 @@ The Encryption scheme is similar to the one used for WebM, using the `ContentEnc
 
 Protected `Blocks` MUST be exactly spanned by one or more contiguous partitions.
 
-* An OBU MAY be spanned by one or more partitions, especially when it has multiple ranges of protected data. However writers SHOULD reduce the number of partitions as possible. This can be achieved by using a partition that spans multiple consecutive unprotected OBUs as well as the first unprotected part of the following protected OBU, if such protected OBU exists.
+* An OBU has clear parts and may have and encrypted parts. These parts are defined as sections. A partition contains one or more contiguous sections, all of which are either encrypted or clear.
 
-* A large subsample that is larger than the maximum size of a single partition (stored on 32 bits integer) MAY be spanned over multiple partitions separated by a zero-size partition, since the partitions alternate protected/unprotected partitions.
+* Writers SHOULD reduce the number of partitions as possible. This can be achieved by merging all contiguous sections of the same type (encrypted or clear) in a single partition. A partition SHOULD span sections from multiple OBUs when possible.
+
+* If one or more section to merge in a partition is larger than the maximum size of a single partition (stored on 32 bits integer), the section(s) MUST be spanned over multiple partitions separated by a zero-size partition, since the partitions alternate protected/unprotected partitions.
 
 
 Within a protected `Block`, the following constraints apply to all the OBUs it contains:

--- a/codec/av1.md
+++ b/codec/av1.md
@@ -156,6 +156,8 @@ Protected `Blocks` MUST be exactly spanned by one or more contiguous partitions.
 
 Within a protected `Block`, the following constraints apply to all the OBUs it contains:
 
+* Clear partitions can contain any number of bytes (up to its maximum size).
+
 * Encrypted partitions MUST be a multiple of 16 bytes.
 
 * Encrypted partitions MUST end on the last byte of the merged encrypted sections.


### PR DESCRIPTION
The WebM spec talks about partitions (the physical way of storing clear/encrypted parts) and sections which are part of the codec data.

This PR uses these 2 notions for a more refined and generic way of describing the 16-bytes end aligned encrypted buffers. The sections are merged to form one or more partition (clear or encrypted). An encrypted partition is not created for tiles that are too small. These are merged with the clear sections before them.

The Metadata OBU is also set to use the 16-bytes end aligned encrypted buffers system.