### PR TITLE
Targets shouldn't be mandatory

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -918,7 +918,7 @@
   <element name="Tag" path="1*(\Segment\Tags\Tag)" id="0x7373" type="master" minOccurs="1" minver="1" webm="1">
     <documentation lang="en">A single metadata descriptor.</documentation>
   </element>
-  <element name="Targets" path="1*1(\Segment\Tags\Tag\Targets)" cppname="TagTargets" id="0x63C0" type="master" minOccurs="1" maxOccurs="1" minver="1" webm="1">
+  <element name="Targets" path="0*1(\Segment\Tags\Tag\Targets)" cppname="TagTargets" id="0x63C0" type="master" maxOccurs="1" minver="1" webm="1">
     <documentation lang="en">Specifies which other elements the metadata represented by the Tag applies to. If empty or not present, then the Tag describes everything in the Segment.</documentation>
   </element>
   <element name="TargetTypeValue" path="0*1(\Segment\Tags\Tag\Targets\TargetTypeValue)" cppname="TagTargetTypeValue" id="0x68CA" type="uinteger" maxOccurs="1" minver="1" webm="1" default="50">


### PR DESCRIPTION
There is currently a mismatch in the definition of `Targets`: On the one hand, it is mandatory (minOccurs="1"), while on the other hand the description describes what happens when this element is not present. This conflict is resolved by keeping the description and changing the syntax, because this saves space for the not uncommon use-case in which the tag applies to the whole segment. Furthermore, changing it in this way doesn't invalidate any existing files, whereas changing the description to match the syntax would potentially invalidate files that abide by the current description and not the syntax.

The mismatch has been introduced with PR #120.